### PR TITLE
Add Phase 3: context assembly, lifecycle, and governance hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "lattice evaluate",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/lattice/SKILL.md
+++ b/.claude/skills/lattice/SKILL.md
@@ -102,6 +102,18 @@ lattice fact ls --json
 lattice fact edit ADR-03
 ```
 
+### Promoting through lifecycle
+
+```bash
+# Draft -> Under Review (one step per invocation)
+lattice fact promote ADR-03 --reason "Ready for peer review"
+
+# Under Review -> Active
+lattice fact promote ADR-03 --reason "Reviewed and approved"
+```
+
+New facts default to `Draft`. They must be promoted through `Under Review` to `Active` before they appear in agent context. The `--reason` flag is required.
+
 ### Deprecating (no hard deletes)
 
 ```bash
@@ -149,6 +161,30 @@ lattice graph contradictions --json
 ```
 
 These are candidates for human review — not confirmed contradictions.
+
+## Context Assembly (Phase 3)
+
+Assemble governed, token-budgeted facts for an agent role:
+
+```bash
+# Assemble facts for the planning role
+lattice context planning
+
+# With a token budget — loads highest-priority facts first
+lattice context planning --budget 4000
+
+# JSON output for piping into agent prompts
+lattice context planning --json
+```
+
+**Priority loading** (per AUP-07):
+1. Confirmed facts first, sorted by tag relevance to the role
+2. Provisional facts if budget remains
+3. Never Draft, Deprecated, or Superseded
+
+Facts that exist but weren't loaded are listed as **REFS pointers** so the agent knows what it's missing.
+
+Available roles are defined in `.lattice/roles/*.yaml`. Default roles: `planning`, `architecture`, `implementation`, `qa`, `deploy`.
 
 ## Git Integration (Phase 2)
 

--- a/.lattice/facts/AUP-08.yaml
+++ b/.lattice/facts/AUP-08.yaml
@@ -13,9 +13,9 @@ tags:
 - governance
 - lifecycle
 - workflow
-status: Draft
-confidence: Provisional
-version: 1
+status: Active
+confidence: Confirmed
+version: 3
 refs:
 - DG-06
 - DG-04
@@ -24,4 +24,4 @@ superseded_by:
 owner: architecture-team
 review_by: '2026-09-01'
 created_at: '2026-03-05T13:13:58.193764'
-updated_at: '2026-03-05T13:13:58.193797'
+updated_at: '2026-03-05T13:33:12.765374'

--- a/.lattice/facts/DG-04.yaml
+++ b/.lattice/facts/DG-04.yaml
@@ -1,11 +1,12 @@
 code: DG-04
 layer: GUARDRAILS
 type: Data Governance Rule
-fact: The lattice fact ls command defaults to showing only Active facts. 
-  Deprecated and Superseded facts are hidden from default listings to reduce 
-  noise. Users can override this with --status filters to see all lifecycle 
-  states. This ensures day-to-day workflows focus on current knowledge without 
-  losing access to historical decisions.
+fact: The lattice fact ls command defaults to showing Active, Draft, and Under 
+  Review facts. Deprecated and Superseded facts are hidden from default listings
+  to reduce noise. Users can override this with --status filters to see all 
+  lifecycle states. This default ensures developers see both current knowledge 
+  and in-progress facts awaiting promotion, while hiding retired facts from 
+  day-to-day workflows.
 tags:
 - cli
 - developer-experience
@@ -13,7 +14,7 @@ tags:
 - status-filter
 status: Active
 confidence: Confirmed
-version: 1
+version: 2
 refs:
 - ADR-05
 - SP-01
@@ -21,4 +22,4 @@ superseded_by:
 owner: architecture-team
 review_by: '2026-09-01'
 created_at: '2026-03-05T13:00:32.201052'
-updated_at: '2026-03-05T13:00:32.201085'
+updated_at: '2026-03-05T14:49:41.992659'

--- a/.lattice/facts/PRD-03.yaml
+++ b/.lattice/facts/PRD-03.yaml
@@ -13,9 +13,9 @@ tags:
 - context-assembly
 - lifecycle
 - phase-3
-status: Draft
-confidence: Provisional
-version: 1
+status: Active
+confidence: Confirmed
+version: 3
 refs:
 - DG-06
 - AUP-08
@@ -26,4 +26,4 @@ superseded_by:
 owner: architecture-team
 review_by: '2026-09-01'
 created_at: '2026-03-05T13:13:58.831406'
-updated_at: '2026-03-05T13:13:58.831436'
+updated_at: '2026-03-05T13:33:03.842522'

--- a/.lattice/facts/RISK-07.yaml
+++ b/.lattice/facts/RISK-07.yaml
@@ -1,0 +1,29 @@
+code: RISK-07
+layer: GUARDRAILS
+type: Risk Register Entry
+fact: "The lattice evaluate command rebuilds the full FactIndex on every invocation
+  by scanning all YAML files in .lattice/facts/. When triggered by an external hook
+  system on every user prompt, this adds per-prompt I/O overhead proportional to total
+  fact count. At the current scale (tens to low hundreds of facts) this completes
+  in under 100ms and is acceptable. At 1,000+ facts the cumulative overhead may become
+  noticeable. Mitigation: future phases could introduce a cached index with file-watcher
+  invalidation, or the evaluate command could read only GUARDRAILS-prefixed files
+  (AUP-*, DG-*, RISK-*, MC-*, COMP-*) instead of building the full index. This risk
+  extends RISK-02's index rebuild concern to the new evaluate code path."
+tags:
+- evaluate
+- index
+- performance
+- risk
+- scaling
+status: Draft
+confidence: Provisional
+version: 1
+refs:
+- RISK-02
+- DES-02
+superseded_by:
+owner: architecture-team
+review_by: '2026-09-01'
+created_at: '2026-03-05T15:45:02.295416'
+updated_at: '2026-03-05T15:45:02.295448'

--- a/.lattice/history/changelog.jsonl
+++ b/.lattice/history/changelog.jsonl
@@ -59,3 +59,9 @@
 {"timestamp": "2026-03-05T13:06:56.200734", "action": "create", "code": "RISK-06", "reason": "Initial creation"}
 {"timestamp": "2026-03-05T13:13:58.197340", "action": "create", "code": "AUP-08", "reason": "Initial creation"}
 {"timestamp": "2026-03-05T13:13:58.835005", "action": "create", "code": "PRD-03", "reason": "Initial creation"}
+{"timestamp": "2026-03-05T13:32:56.019330", "action": "update", "code": "PRD-03", "reason": "Promoted to Under Review: Phase 3 implementation starting, requirements reviewed and accepted"}
+{"timestamp": "2026-03-05T13:33:03.846309", "action": "update", "code": "PRD-03", "reason": "Promoted to Active: Requirements validated, ready for active use"}
+{"timestamp": "2026-03-05T13:33:12.139173", "action": "update", "code": "AUP-08", "reason": "Promoted to Under Review: Lifecycle enforcement policy reviewed"}
+{"timestamp": "2026-03-05T13:33:12.768360", "action": "update", "code": "AUP-08", "reason": "Promoted to Active: Policy validated and accepted for enforcement"}
+{"timestamp": "2026-03-05T14:49:41.995337", "action": "update", "code": "DG-04", "reason": "Updated to match actual fact ls default: Active+Draft+Under Review (not Active-only)"}
+{"timestamp": "2026-03-05T15:45:02.299981", "action": "create", "code": "RISK-07", "reason": "Initial creation"}

--- a/README.md
+++ b/README.md
@@ -93,9 +93,14 @@ lattice fact add --from my-fact.yaml
 # Open in $EDITOR, validates on save, bumps version
 lattice fact edit ADR-03
 
+# Promote through lifecycle: Draft -> Under Review -> Active
+lattice fact promote ADR-03 --reason "Reviewed and approved by team"
+
 # Soft delete (no hard deletes — facts are Deprecated, never removed)
 lattice fact deprecate ADR-03 --reason "Superseded by ADR-04"
 ```
+
+New facts default to `Draft` status and must be promoted through the lifecycle before they appear in agent context.
 
 ### Validate integrity
 
@@ -124,6 +129,24 @@ lattice graph contradictions
 ```
 
 All graph commands support `--json` for machine-readable output.
+
+### Context assembly
+
+```bash
+# Assemble governed facts for the planning agent role
+lattice context planning
+
+# Respect a token budget — loads highest-priority facts first
+lattice context planning --budget 4000
+
+# JSON output — pipe directly into an agent prompt
+lattice context planning --json
+
+# Different roles get different facts
+lattice context architecture --budget 8000 --json
+```
+
+Context assembly follows priority loading: Confirmed facts first, then Provisional if budget remains. Draft, Deprecated, and Superseded facts are never included. Facts that exist but weren't loaded are listed as REFS pointers so the agent knows what it's missing.
 
 ### Git integration
 
@@ -206,6 +229,122 @@ review_by: 2026-06-01
 
 ## Claude Code Integration
 
+### Governance Hook (Recommended)
+
+LatticeLens includes a `UserPromptSubmit` hook that automatically injects your project's governance rules into every Claude Code conversation. When active, the hook:
+
+1. **Enforces governance** — All active GUARDRAILS-layer rules (AUP, DG, RISK, MC) are injected as mandatory context. The agent is instructed to follow these rules and **raise conflicts before proceeding** if a request would violate any rule, citing the specific rule code.
+2. **Encourages knowledge discovery** — A summary of available WHY/HOW facts is included with instructions to run `lattice context <role> --json` before starting development work.
+3. **Silent when absent** — If the project has no `.lattice/` directory, the hook produces no output and does not interfere.
+
+#### Setup
+
+**Step 1:** Install LatticeLens so the `lattice` command is on your PATH:
+
+```bash
+pip install -e .
+```
+
+**Step 2:** Add the hook configuration to your project's `.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "lattice evaluate",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+That's it. Every prompt you submit in Claude Code will now be preceded by the project's governance briefing.
+
+#### What the agent sees
+
+When you submit a prompt, Claude sees something like:
+
+```
+# LatticeLens Governance Briefing
+
+## Mandatory Rules
+You MUST follow these governance rules for this project. If the user's
+request would violate any of these rules, you MUST raise the conflict
+before proceeding — cite the specific rule code (e.g. AUP-01)...
+
+### [AUP-01] Acceptable Use Policy Rule (Confirmed)
+Facts are never hard-deleted...
+
+### [DG-06] Data Governance Rule (Confirmed)
+Facts progress through a defined lifecycle...
+
+## Project Knowledge Available
+This project has a knowledge lattice you should consult before development:
+
+**WHY layer** (architectural decisions & requirements):
+- 13 Architecture Decision Records
+- 3 Product Requirements
+...
+
+### Before starting work, load relevant context:
+- For planning/scoping: `lattice context planning --json`
+- For coding tasks: `lattice context implementation --json`
+...
+```
+
+#### Manual testing
+
+You can preview what the hook outputs at any time:
+
+```bash
+# Text briefing (what Claude sees)
+lattice evaluate
+
+# JSON format (for scripting or the agent hook variant)
+lattice evaluate --json
+
+# Test from a specific directory
+lattice evaluate --path /path/to/project
+
+# Diagnostics on stderr
+lattice evaluate --verbose
+```
+
+#### Agent hook variant (optional)
+
+For deeper AI-powered evaluation, you can use an agent-type hook instead of (or in addition to) the command hook. This spawns a Claude sub-agent that loads the lattice context and reasons about whether the prompt aligns with governance rules:
+
+```json
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "agent",
+            "prompt": "You are a governance reviewer. Run `lattice evaluate --json` to load this project's governance rules and knowledge summary. Then evaluate whether the user's prompt might lead to actions that violate any governance rules, or whether there are relevant architectural decisions or design patterns the agent should review first. Output your assessment. $ARGUMENTS",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+This is slower (~5–10s per prompt) but can catch subtler conflicts that simple context injection might miss.
+
+### Skill
+
 A `/lattice` skill is included for Claude Code users. Type `/lattice` in any Claude Code session to get usage guidance, or `/lattice how do I filter by tag` to ask a specific question.
 
 To make it available globally (outside this repo), copy the skill to your personal skills directory:
@@ -233,13 +372,13 @@ ruff check src/ tests/
 
 Git-native fact storage, full CRUD, filtering, validation, seed data. The foundation everything else builds on.
 
-### Phase 2 — Knowledge Graph + Git Integration (current)
+### Phase 2 — Knowledge Graph + Git Integration ✓
 
 Impact analysis (`lattice graph impact`), orphan detection, contradiction candidates, git-aware diffs (`lattice diff`) and history (`lattice log`), versioned schema upgrades (`lattice upgrade`).
 
-### Phase 3 — Context Assembly Engine
+### Phase 3 — Context Assembly + Fact Lifecycle ✓
 
-Role-scoped, token-budgeted context assembly. Run `lattice context planning` and get exactly the facts the Planning Agent needs, fitted to a token budget.
+Lifecycle commands (`lattice fact promote`), role-scoped token-budgeted context assembly (`lattice context planning --budget 4000`), priority loading (Confirmed first, Provisional if budget remains), REFS pointers for excluded facts.
 
 ### Phase 4 — LLM Extraction + Import/Export
 

--- a/src/lattice_lens/cli/context_commands.py
+++ b/src/lattice_lens/cli/context_commands.py
@@ -1,0 +1,99 @@
+"""lattice context — role-based context assembly for agent prompts."""
+
+from __future__ import annotations
+
+import json
+from typing import Optional
+
+import typer
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+
+from lattice_lens.cli.helpers import require_lattice
+from lattice_lens.config import ROLES_DIR
+from lattice_lens.services.context_service import assemble_context, estimate_fact_tokens
+from lattice_lens.services.graph_service import load_role_templates
+
+console = Console()
+err_console = Console(stderr=True)
+
+
+def context(
+    role: str = typer.Argument(help="Role name (matches .lattice/roles/{role}.yaml)"),
+    budget: Optional[int] = typer.Option(
+        None, "--budget", help="Token budget (omit for unlimited)"
+    ),
+    as_json: bool = typer.Option(False, "--json", help="Output assembled context as JSON"),
+):
+    """Assemble governed, token-budgeted facts for an agent role."""
+    store = require_lattice()
+    roles_dir = store.root / ROLES_DIR
+
+    templates = load_role_templates(roles_dir)
+    if not templates:
+        err_console.print(
+            "[red]Error:[/red] No role templates found in .lattice/roles/. "
+            "Run [bold]lattice init[/bold] to create them."
+        )
+        raise typer.Exit(1)
+
+    if role not in templates:
+        available = ", ".join(sorted(templates.keys()))
+        err_console.print(
+            f"[red]Error:[/red] Role '{role}' not found. "
+            f"Available roles: {available}"
+        )
+        raise typer.Exit(1)
+
+    template = templates[role]
+    result = assemble_context(store.index, role, template, budget=budget)
+
+    if as_json:
+        print(json.dumps(result.to_dict(), indent=2))
+        return
+
+    # Rich output
+    role_name = template.get("name", role)
+    role_desc = template.get("description", "")
+
+    header = f"[bold]{role_name}[/bold]"
+    if role_desc:
+        header += f"\n[dim]{role_desc}[/dim]"
+
+    summary_parts = [f"Facts loaded: [bold]{len(result.loaded_facts)}[/bold]"]
+    summary_parts.append(f"Estimated tokens: [bold]{result.total_tokens}[/bold]")
+    if result.budget is not None:
+        summary_parts.append(f"Budget: {result.budget}")
+        if result.budget_exhausted:
+            summary_parts.append("[yellow]Budget exhausted[/yellow]")
+    console.print(Panel(header + "\n" + " | ".join(summary_parts), border_style="blue"))
+
+    if not result.loaded_facts:
+        console.print("[dim]No facts matched this role's query.[/dim]")
+        return
+
+    # Facts table
+    table = Table(title="Assembled Facts")
+    table.add_column("Code", style="bold")
+    table.add_column("Layer")
+    table.add_column("Type")
+    table.add_column("Confidence")
+    table.add_column("Tokens", justify="right")
+
+    for fact in result.loaded_facts:
+        table.add_row(
+            fact.code,
+            fact.layer.value,
+            fact.type,
+            fact.confidence.value,
+            str(estimate_fact_tokens(fact)),
+        )
+
+    console.print(table)
+
+    # Ref pointers
+    if result.ref_pointers:
+        console.print("\n[dim]Additional facts not loaded (REFS pointers):[/dim]")
+        for ptr in result.ref_pointers:
+            console.print(f"  [dim]- {ptr}[/dim]")

--- a/src/lattice_lens/cli/evaluate_command.py
+++ b/src/lattice_lens/cli/evaluate_command.py
@@ -1,0 +1,94 @@
+"""lattice evaluate — governance evaluation for Claude Code hooks.
+
+When invoked as a Claude Code ``UserPromptSubmit`` hook the command reads
+the hook payload from *stdin*, locates the project's ``.lattice/``
+directory, and prints a governance briefing to *stdout*.  Claude Code
+captures that stdout and injects it as context the model sees before
+processing the user's prompt.
+
+Can also be run standalone for debugging or manual evaluation::
+
+    lattice evaluate              # text briefing
+    lattice evaluate --json       # JSON output
+    lattice evaluate --verbose    # diagnostics on stderr
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Optional
+
+import typer
+from rich.console import Console
+
+from lattice_lens.services.evaluate_service import (
+    evaluate_governance,
+    parse_hook_input,
+)
+
+err_console = Console(stderr=True)
+
+
+def evaluate(
+    as_json: bool = typer.Option(
+        False, "--json", help="Output governance briefing as JSON."
+    ),
+    path: Optional[Path] = typer.Option(
+        None,
+        "--path",
+        help="Directory to evaluate (default: hook stdin cwd, or cwd).",
+    ),
+    verbose: bool = typer.Option(
+        False, "--verbose", help="Print diagnostics to stderr."
+    ),
+) -> None:
+    """Evaluate governance rules for Claude Code hook injection.
+
+    When used as a Claude Code UserPromptSubmit hook, reads stdin JSON to
+    get the project directory.  When used standalone, uses --path or the
+    current working directory.
+
+    Exit codes:
+      0 — success (stdout may have governance briefing, or empty if no lattice)
+    """
+    target_path: Path | None = path
+
+    # Try reading stdin for hook mode (non-interactive only)
+    if target_path is None:
+        try:
+            if not sys.stdin.isatty():
+                stdin_data = sys.stdin.read()
+                hook_input = parse_hook_input(stdin_data)
+                if hook_input and hook_input.cwd:
+                    target_path = Path(hook_input.cwd)
+                    if verbose:
+                        err_console.print(
+                            f"[dim]Hook mode: cwd={hook_input.cwd}, "
+                            f"event={hook_input.hook_event_name}[/dim]"
+                        )
+        except Exception:
+            # Never crash on stdin issues — fall through to cwd discovery
+            pass
+
+    # Run the evaluation
+    result = evaluate_governance(start_path=target_path)
+
+    if verbose:
+        err_console.print(
+            f"[dim]Lattice found: {result.lattice_found}, "
+            f"guardrails: {len(result.guardrails)}, "
+            f"tokens: {result.total_tokens}, "
+            f"roles: {len(result.available_roles)}[/dim]"
+        )
+
+    # Output — always exit 0.  Empty stdout = silent no-op for the hook.
+    if as_json:
+        sys.stdout.write(json.dumps(result.to_dict(), indent=2))
+        sys.stdout.write("\n")
+    else:
+        briefing = result.render_briefing()
+        if briefing:
+            sys.stdout.write(briefing)
+            sys.stdout.write("\n")

--- a/src/lattice_lens/cli/fact_commands.py
+++ b/src/lattice_lens/cli/fact_commands.py
@@ -21,11 +21,13 @@ from lattice_lens.cli.helpers import require_lattice
 from lattice_lens.config import LAYER_PREFIXES
 from lattice_lens.models import Fact, FactConfidence, FactLayer, FactStatus
 from lattice_lens.services.fact_service import (
+    PROMOTION_TRANSITIONS,
     check_refs,
     create_fact,
     infer_layer,
     is_stale,
     next_code,
+    promote_fact,
 )
 
 console = Console()
@@ -65,6 +67,14 @@ def _add_from_file(store, path: Path):
     except ValidationError as e:
         err_console.print(f"[red]Validation error:[/red]\n{e}")
         raise typer.Exit(1)
+
+    # AUP-08: Warn when importing a fact that isn't Draft
+    if fact.status != FactStatus.DRAFT:
+        console.print(
+            f"[yellow]Warning:[/yellow] Fact {fact.code} has status '{fact.status.value}'. "
+            f"Per AUP-08, new facts should start as Draft and be promoted via "
+            f"[bold]lattice fact promote[/bold]."
+        )
 
     try:
         created, warnings = create_fact(store, fact)
@@ -305,6 +315,22 @@ def fact_edit(
                 console.print("[dim]No changes detected.[/dim]")
                 raise typer.Exit(0)
 
+            # Block promotion-direction status changes — use `lattice fact promote`
+            if "status" in changes:
+                old_status = FactStatus(old_data["status"])
+                new_status = FactStatus(changes["status"])
+                if PROMOTION_TRANSITIONS.get(old_status) == new_status:
+                    err_console.print(
+                        f"[red]Error:[/red] Cannot promote {code} via edit. "
+                        f"Use [bold]lattice fact promote {code} --reason \"...\"[/bold] "
+                        f"to transition {old_status.value} → {new_status.value}."
+                    )
+                    retry = typer.confirm("Re-edit?", default=True)
+                    if not retry:
+                        console.print("[yellow]Aborted.[/yellow]")
+                        raise typer.Exit(0)
+                    continue
+
             result = store.update(code, changes, "Edited via CLI")
             warnings = check_refs(store, result.refs)
             for w in warnings:
@@ -315,6 +341,29 @@ def fact_edit(
             break
     finally:
         Path(tmp_path).unlink(missing_ok=True)
+
+
+@fact_app.command("promote")
+def fact_promote(
+    code: str = typer.Argument(help="Fact code to promote"),
+    reason: str = typer.Option(..., "--reason", help="Reason for promotion"),
+):
+    """Promote a fact: Draft -> Under Review -> Active."""
+    store = require_lattice()
+
+    try:
+        result = promote_fact(store, code, reason)
+    except FileNotFoundError:
+        err_console.print(f"[red]Error:[/red] Fact '{code}' not found")
+        raise typer.Exit(1)
+    except ValueError as e:
+        err_console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(1)
+
+    console.print(
+        f"[green]Promoted[/green] {result.code} to {result.status.value} "
+        f"(v{result.version}): {reason}"
+    )
 
 
 @fact_app.command("deprecate")

--- a/src/lattice_lens/cli/main.py
+++ b/src/lattice_lens/cli/main.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import typer
 
+from lattice_lens.cli.context_commands import context
+from lattice_lens.cli.evaluate_command import evaluate
 from lattice_lens.cli.fact_commands import fact_app
 from lattice_lens.cli.git_commands import diff, log
 from lattice_lens.cli.graph_commands import graph_app
@@ -19,7 +21,7 @@ app = typer.Typer(
     no_args_is_help=True,
 )
 
-app.add_typer(fact_app, name="fact", help="Manage facts (add, get, ls, edit, deprecate).")
+app.add_typer(fact_app, name="fact", help="Manage facts (add, get, ls, edit, promote, deprecate).")
 app.add_typer(graph_app, name="graph", help="Knowledge graph analysis.")
 app.command()(init)
 app.command()(validate)
@@ -29,6 +31,8 @@ app.command()(status)
 app.command()(diff)
 app.command("log")(log)
 app.command()(upgrade)
+app.command()(context)
+app.command()(evaluate)
 
 
 if __name__ == "__main__":

--- a/src/lattice_lens/services/context_service.py
+++ b/src/lattice_lens/services/context_service.py
@@ -1,0 +1,223 @@
+"""Context assembly — role-based, token-budgeted fact selection for agent prompts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from lattice_lens.models import Fact, FactConfidence, FactStatus
+from lattice_lens.services.fact_service import is_stale
+from lattice_lens.services.graph_service import _get_query, _role_matches_fact
+from lattice_lens.store.index import FactIndex
+
+
+def estimate_tokens(text: str) -> int:
+    """Estimate token count using character-based heuristic.
+
+    Average English token is ~4 characters. This avoids a tiktoken dependency
+    while being accurate enough for budget enforcement.
+    """
+    return max(1, len(text) // 4)
+
+
+def estimate_fact_tokens(fact: Fact) -> int:
+    """Estimate the total token cost of a fact in assembled context.
+
+    Includes: code, layer, type, status, confidence, tags, refs, fact text.
+    """
+    parts = [
+        f"[{fact.code}]",
+        f"Layer: {fact.layer.value}",
+        f"Type: {fact.type}",
+        f"Status: {fact.status.value}",
+        f"Confidence: {fact.confidence.value}",
+        f"Tags: {', '.join(fact.tags)}",
+    ]
+    if fact.refs:
+        parts.append(f"Refs: {', '.join(fact.refs)}")
+    parts.append(fact.fact)
+    return estimate_tokens("\n".join(parts))
+
+
+# Statuses that are NEVER included in context assembly
+_EXCLUDED_STATUSES = {
+    FactStatus.DRAFT,
+    FactStatus.DEPRECATED,
+    FactStatus.SUPERSEDED,
+}
+
+
+def _tag_match_score(fact: Fact, role_tags: list[str]) -> int:
+    """Score a fact by how many of the role's tags it matches."""
+    if not role_tags:
+        return 0
+    return len(set(fact.tags) & set(role_tags))
+
+
+@dataclass
+class ContextResult:
+    """Result of a context assembly for an agent role."""
+
+    role: str
+    loaded_facts: list[Fact] = field(default_factory=list)
+    ref_pointers: list[str] = field(default_factory=list)
+    total_tokens: int = 0
+    budget: int | None = None
+    budget_exhausted: bool = False
+
+    def render_text(self) -> str:
+        """Render assembled context as text for agent prompts."""
+        lines: list[str] = []
+        lines.append(f"# Context for role: {self.role}")
+        lines.append(f"# Facts loaded: {len(self.loaded_facts)}")
+        lines.append(f"# Estimated tokens: {self.total_tokens}")
+        if self.budget is not None:
+            lines.append(f"# Token budget: {self.budget}")
+        lines.append("")
+
+        for fact in self.loaded_facts:
+            lines.append(f"## [{fact.code} v{fact.version}] {fact.type}")
+            lines.append(f"Layer: {fact.layer.value} | "
+                         f"Status: {fact.status.value} | "
+                         f"Confidence: {fact.confidence.value}")
+            lines.append(f"Tags: {', '.join(fact.tags)}")
+            if fact.refs:
+                lines.append(f"Refs: {', '.join(fact.refs)}")
+            lines.append("")
+            lines.append(fact.fact)
+            lines.append("")
+
+        if self.ref_pointers:
+            lines.append("---")
+            lines.append("# Additional facts exist but were not loaded:")
+            for ptr in self.ref_pointers:
+                lines.append(f"#   - {ptr}")
+            lines.append("")
+
+        return "\n".join(lines)
+
+    def to_dict(self) -> dict:
+        """Serialize to dict for JSON output."""
+        return {
+            "role": self.role,
+            "facts_loaded": len(self.loaded_facts),
+            "total_tokens": self.total_tokens,
+            "budget": self.budget,
+            "budget_exhausted": self.budget_exhausted,
+            "facts": [
+                {
+                    "code": f.code,
+                    "version": f.version,
+                    "layer": f.layer.value,
+                    "type": f.type,
+                    "status": f.status.value,
+                    "confidence": f.confidence.value,
+                    "tags": f.tags,
+                    "refs": f.refs,
+                    "fact": f.fact,
+                    "tokens": estimate_fact_tokens(f),
+                }
+                for f in self.loaded_facts
+            ],
+            "ref_pointers": self.ref_pointers,
+        }
+
+
+def assemble_context(
+    index: FactIndex,
+    role_name: str,
+    role_template: dict,
+    budget: int | None = None,
+) -> ContextResult:
+    """Assemble facts for a role, respecting lifecycle and token budget.
+
+    Priority loading per AUP-07:
+    1. Confirmed facts first (Active with Confirmed confidence)
+    2. Provisional facts if budget remains (Under Review, or Active with Provisional)
+    3. Never Draft, Deprecated, or Superseded
+
+    Within each confidence tier, sort by tag match score (descending).
+    """
+    query = _get_query(role_template)
+    role_tags = query.get("tags", [])
+    max_facts = query.get("max_facts")
+
+    # Collect all facts that match the role query
+    matched: list[Fact] = []
+    for fact in index.all_facts():
+        if fact.status in _EXCLUDED_STATUSES:
+            continue
+        if _role_matches_fact(role_template, fact.layer.value, fact.type):
+            matched.append(fact)
+
+    # Split into priority tiers.
+    # DG-06: stale facts (past review_by) are downgraded to Provisional tier
+    # regardless of their stored confidence. This is a runtime-only downgrade —
+    # the YAML file is not modified.
+    confirmed: list[Fact] = []
+    provisional: list[Fact] = []
+
+    for fact in matched:
+        if is_stale(fact):
+            # Review Expired — downgrade to Provisional tier per DG-06
+            provisional.append(fact)
+        elif fact.confidence == FactConfidence.CONFIRMED:
+            confirmed.append(fact)
+        elif fact.confidence == FactConfidence.PROVISIONAL:
+            provisional.append(fact)
+        else:
+            # Assumed confidence — treat like Provisional
+            provisional.append(fact)
+
+    # Sort each tier by tag match score (descending), then code for stability
+    def sort_key(f: Fact) -> tuple:
+        return (-_tag_match_score(f, role_tags), f.code)
+
+    confirmed.sort(key=sort_key)
+    provisional.sort(key=sort_key)
+
+    # Priority loading: Confirmed first, then Provisional
+    ordered = confirmed + provisional
+
+    # Apply max_facts limit from role template
+    if max_facts is not None:
+        ordered = ordered[:max_facts]
+
+    # Load facts within budget
+    result = ContextResult(role=role_name, budget=budget)
+    loaded_codes: set[str] = set()
+
+    for fact in ordered:
+        tokens = estimate_fact_tokens(fact)
+        if budget is not None and result.total_tokens + tokens > budget:
+            result.budget_exhausted = True
+            break
+        result.loaded_facts.append(fact)
+        result.total_tokens += tokens
+        loaded_codes.add(fact.code)
+
+    # Build REFS pointers for facts that exist but weren't loaded.
+    # Include: facts matching the role that were cut by budget/max_facts,
+    # plus any refs from loaded facts that point to unloaded facts.
+    all_matched_codes = {f.code for f in matched}
+    not_loaded_from_match = all_matched_codes - loaded_codes
+
+    # Also include refs from loaded facts that point outside the loaded set
+    refs_outside: set[str] = set()
+    for fact in result.loaded_facts:
+        for ref in fact.refs:
+            if ref not in loaded_codes:
+                ref_fact = index.get(ref)
+                if ref_fact and ref_fact.status not in _EXCLUDED_STATUSES:
+                    refs_outside.add(ref)
+
+    all_pointers = sorted(not_loaded_from_match | refs_outside)
+    for code in all_pointers:
+        ptr_fact = index.get(code)
+        if ptr_fact:
+            result.ref_pointers.append(
+                f"{code} ({ptr_fact.layer.value}/{ptr_fact.type})"
+            )
+        else:
+            result.ref_pointers.append(code)
+
+    return result

--- a/src/lattice_lens/services/evaluate_service.py
+++ b/src/lattice_lens/services/evaluate_service.py
@@ -1,0 +1,279 @@
+"""Governance evaluation service for Claude Code hook integration.
+
+Loads Active GUARDRAILS-layer facts and summarises available WHY/HOW
+knowledge so that the injected context both *enforces* governance rules
+and *encourages* the agent to consult relevant architectural decisions,
+design patterns, and operational runbooks before starting work.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from lattice_lens.config import ROLES_DIR, find_lattice_root
+from lattice_lens.models import Fact, FactConfidence
+from lattice_lens.services.context_service import estimate_tokens
+from lattice_lens.services.graph_service import load_role_templates
+from lattice_lens.store.yaml_store import YamlFileStore
+
+
+# ---------------------------------------------------------------------------
+# Hook input parsing
+# ---------------------------------------------------------------------------
+
+@dataclass
+class HookInput:
+    """Parsed Claude Code hook stdin payload."""
+
+    session_id: str = ""
+    cwd: str = ""
+    hook_event_name: str = ""
+    prompt: str = ""
+
+
+def parse_hook_input(stdin_data: str) -> HookInput | None:
+    """Parse Claude Code UserPromptSubmit hook stdin JSON.
+
+    Returns ``None`` when *stdin_data* is empty, whitespace-only, or not
+    valid JSON — indicating the command is being run standalone rather
+    than as a hook.
+    """
+    if not stdin_data or not stdin_data.strip():
+        return None
+    try:
+        data = json.loads(stdin_data)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    return HookInput(
+        session_id=data.get("session_id", ""),
+        cwd=data.get("cwd", ""),
+        hook_event_name=data.get("hook_event_name", ""),
+        prompt=data.get("prompt", ""),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Evaluation result
+# ---------------------------------------------------------------------------
+
+@dataclass
+class EvaluationResult:
+    """Result of a governance evaluation for Claude Code hook injection."""
+
+    lattice_found: bool = False
+    guardrails: list[Fact] = field(default_factory=list)
+    knowledge_summary: dict[str, dict[str, int]] = field(default_factory=dict)
+    available_roles: list[str] = field(default_factory=list)
+    total_tokens: int = 0
+    lattice_root: str = ""
+
+    @property
+    def has_governance(self) -> bool:
+        """True when there is a lattice with at least one guardrail."""
+        return self.lattice_found and len(self.guardrails) > 0
+
+    # -- rendering ----------------------------------------------------------
+
+    def render_briefing(self) -> str:
+        """Render the full governance briefing as plain text.
+
+        This text is emitted on *stdout* by the ``lattice evaluate``
+        command.  When the command is invoked as a Claude Code
+        ``UserPromptSubmit`` hook, Claude Code injects the text as
+        additional context that the model sees before processing the
+        user's prompt.
+
+        Returns an empty string when there is nothing to inject (no
+        lattice found, or no active guardrails).
+        """
+        if not self.lattice_found:
+            return ""
+
+        # Even if there are no guardrails, we still want to show the
+        # knowledge discovery section if the lattice exists.
+        has_knowledge = any(self.knowledge_summary.values())
+        if not self.has_governance and not has_knowledge:
+            return ""
+
+        lines: list[str] = []
+        lines.append("# LatticeLens Governance Briefing")
+        lines.append("")
+
+        # ---- Section 1: Mandatory governance rules ----
+        if self.guardrails:
+            lines.append("## Mandatory Rules")
+            lines.append(
+                "You MUST follow these governance rules for this project. "
+                "If the user's request would violate any of these rules, "
+                "you MUST raise the conflict before proceeding — cite the "
+                "specific rule code (e.g. AUP-01) and explain why the "
+                "proposed action conflicts with it. Ask the user how they "
+                "would like to proceed rather than silently violating a rule."
+            )
+            lines.append("")
+
+            for fact in self.guardrails:
+                lines.append(
+                    f"### [{fact.code}] {fact.type} ({fact.confidence.value})"
+                )
+                if fact.refs:
+                    lines.append(f"Refs: {', '.join(fact.refs)}")
+                lines.append("")
+                lines.append(fact.fact)
+                lines.append("")
+
+        # ---- Section 2: Knowledge discovery ----
+        if has_knowledge or self.available_roles:
+            lines.append("## Project Knowledge Available")
+            lines.append(
+                "This project has a knowledge lattice you should consult "
+                "before development:"
+            )
+            lines.append("")
+
+            layer_labels = {
+                "WHY": "architectural decisions & requirements",
+                "HOW": "implementation patterns & operations",
+            }
+            for layer in ("WHY", "HOW"):
+                type_counts = self.knowledge_summary.get(layer, {})
+                if not type_counts:
+                    continue
+                lines.append(
+                    f"**{layer} layer** ({layer_labels.get(layer, layer)}):"
+                )
+                for fact_type, count in sorted(type_counts.items()):
+                    lines.append(f"- {count} {fact_type}{'s' if count != 1 else ''}")
+                lines.append("")
+
+            if self.available_roles:
+                lines.append("### Before starting work, load relevant context:")
+                role_hints = {
+                    "planning": "planning/scoping",
+                    "architecture": "design decisions",
+                    "implementation": "coding tasks",
+                    "qa": "testing/QA",
+                    "deploy": "deployment",
+                }
+                for role in sorted(self.available_roles):
+                    hint = role_hints.get(role, role)
+                    lines.append(
+                        f"- For {hint}: `lattice context {role} --json`"
+                    )
+                lines.append(
+                    "- Look up a specific fact: `lattice fact get <CODE> --json`"
+                )
+                lines.append("")
+                lines.append(
+                    "Use the lattice context that best matches your current task."
+                )
+                lines.append("")
+
+        # ---- Footer ----
+        why_count = sum(self.knowledge_summary.get("WHY", {}).values())
+        how_count = sum(self.knowledge_summary.get("HOW", {}).values())
+        lines.append("---")
+        lines.append(
+            f"Source: .lattice/ ({len(self.guardrails)} guardrails, "
+            f"{why_count} WHY facts, {how_count} HOW facts, "
+            f"{len(self.available_roles)} roles)"
+        )
+        return "\n".join(lines)
+
+    def to_dict(self) -> dict:
+        """Serialise to dict for ``--json`` output."""
+        return {
+            "lattice_found": self.lattice_found,
+            "guardrails_count": len(self.guardrails),
+            "total_tokens": self.total_tokens,
+            "lattice_root": self.lattice_root,
+            "guardrails": [
+                {
+                    "code": f.code,
+                    "version": f.version,
+                    "type": f.type,
+                    "confidence": f.confidence.value,
+                    "tags": f.tags,
+                    "refs": f.refs,
+                    "fact": f.fact,
+                }
+                for f in self.guardrails
+            ],
+            "knowledge_summary": self.knowledge_summary,
+            "available_roles": self.available_roles,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Core evaluation function
+# ---------------------------------------------------------------------------
+
+def evaluate_governance(
+    start_path: Path | None = None,
+) -> EvaluationResult:
+    """Load Active GUARDRAILS facts and summarise WHY/HOW knowledge.
+
+    This is the core evaluation engine.  It:
+
+    1. Finds the ``.lattice/`` root (silent if not found).
+    2. Loads all **Active** facts from the **GUARDRAILS** layer.
+    3. Sorts guardrails: Confirmed confidence first, then by code.
+    4. Builds a knowledge summary counting Active WHY/HOW facts by type.
+    5. Lists available role templates.
+
+    Parameters
+    ----------
+    start_path:
+        Directory to search upward from.  When called from a Claude Code
+        hook this is the ``cwd`` field from the hook's stdin JSON.  When
+        ``None`` the current working directory is used.
+    """
+    result = EvaluationResult()
+
+    lattice_root = find_lattice_root(start_path)
+    if lattice_root is None:
+        return result  # silent no-op
+
+    result.lattice_found = True
+    result.lattice_root = str(lattice_root)
+
+    store = YamlFileStore(lattice_root)
+
+    # ---- Guardrails ----
+    guardrails = store.list_facts(layer="GUARDRAILS", status=["Active"])
+
+    def _sort_key(f: Fact) -> tuple:
+        rank = 0 if f.confidence == FactConfidence.CONFIRMED else 1
+        return (rank, f.code)
+
+    guardrails.sort(key=_sort_key)
+    result.guardrails = guardrails
+
+    # Token estimate for the governance portion
+    for fact in guardrails:
+        text = (
+            f"[{fact.code}] {fact.type}\n"
+            f"Confidence: {fact.confidence.value}\n"
+            f"{fact.fact}"
+        )
+        result.total_tokens += estimate_tokens(text)
+
+    # ---- Knowledge summary (WHY + HOW) ----
+    for layer in ("WHY", "HOW"):
+        facts = store.list_facts(layer=layer, status=["Active"])
+        if not facts:
+            continue
+        type_counts: dict[str, int] = {}
+        for f in facts:
+            type_counts[f.type] = type_counts.get(f.type, 0) + 1
+        result.knowledge_summary[layer] = type_counts
+
+    # ---- Available roles ----
+    roles_dir = lattice_root / ROLES_DIR
+    if roles_dir.is_dir():
+        templates = load_role_templates(roles_dir)
+        result.available_roles = sorted(templates.keys())
+
+    return result

--- a/src/lattice_lens/services/fact_service.py
+++ b/src/lattice_lens/services/fact_service.py
@@ -6,7 +6,7 @@ import re
 from datetime import datetime
 
 from lattice_lens.config import LAYER_PREFIXES
-from lattice_lens.models import Fact, FactStatus
+from lattice_lens.models import Fact, FactConfidence, FactStatus
 from lattice_lens.store.yaml_store import YamlFileStore
 
 
@@ -77,3 +77,40 @@ def is_stale(fact: Fact) -> bool:
     if fact.review_by is None:
         return False
     return fact.review_by < datetime.now().date()
+
+
+# Valid lifecycle transitions: current_status -> next_status
+PROMOTION_TRANSITIONS: dict[FactStatus, FactStatus] = {
+    FactStatus.DRAFT: FactStatus.UNDER_REVIEW,
+    FactStatus.UNDER_REVIEW: FactStatus.ACTIVE,
+}
+
+
+def promote_fact(store: YamlFileStore, code: str, reason: str) -> Fact:
+    """Promote a fact one step through the lifecycle.
+
+    Draft -> Under Review -> Active.
+    Raises ValueError if the fact cannot be promoted.
+    """
+    fact = store.get(code)
+    if fact is None:
+        raise FileNotFoundError(f"Fact {code} not found")
+
+    next_status = PROMOTION_TRANSITIONS.get(fact.status)
+    if next_status is None:
+        raise ValueError(
+            f"Cannot promote {code}: status '{fact.status.value}' is not promotable. "
+            f"Only Draft and Under Review facts can be promoted."
+        )
+
+    changes: dict = {"status": next_status.value}
+
+    # When promoting to Active, set confidence to Confirmed
+    if next_status == FactStatus.ACTIVE:
+        changes["confidence"] = FactConfidence.CONFIRMED.value
+
+    # When promoting to Under Review, set confidence to Provisional
+    if next_status == FactStatus.UNDER_REVIEW:
+        changes["confidence"] = FactConfidence.PROVISIONAL.value
+
+    return store.update(code, changes, f"Promoted to {next_status.value}: {reason}")

--- a/tests/test_context_cli.py
+++ b/tests/test_context_cli.py
@@ -1,0 +1,135 @@
+"""CLI integration tests for lattice context command."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from lattice_lens.cli.main import app
+from lattice_lens.config import FACTS_DIR, LATTICE_DIR, ROLES_DIR
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def cli_dir(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+@pytest.fixture
+def initialized_dir(cli_dir: Path):
+    result = runner.invoke(app, ["init"])
+    assert result.exit_code == 0
+    return cli_dir
+
+
+@pytest.fixture
+def seeded_dir(initialized_dir: Path):
+    import shutil
+
+    seed_src = Path(__file__).resolve().parent.parent / "seed"
+    seed_dst = initialized_dir / "seed"
+    if seed_src.exists():
+        shutil.copytree(seed_src, seed_dst, dirs_exist_ok=True)
+
+    result = runner.invoke(app, ["seed"])
+    assert result.exit_code == 0
+    return initialized_dir
+
+
+class TestContextCommand:
+    def test_context_basic(self, seeded_dir):
+        result = runner.invoke(app, ["context", "planning"])
+        assert result.exit_code == 0
+        assert "Planning Agent" in result.output
+        assert "Facts loaded" in result.output
+
+    def test_context_json(self, seeded_dir):
+        result = runner.invoke(app, ["context", "planning", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["role"] == "planning"
+        assert "facts" in data
+        assert isinstance(data["facts"], list)
+        assert "ref_pointers" in data
+
+    def test_context_with_budget(self, seeded_dir):
+        result = runner.invoke(app, ["context", "planning", "--budget", "300"])
+        assert result.exit_code == 0
+        assert "Budget" in result.output or "budget" in result.output.lower()
+
+    def test_context_json_with_budget(self, seeded_dir):
+        result = runner.invoke(app, ["context", "planning", "--budget", "300", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["budget"] == 300
+        assert data["total_tokens"] <= 300
+
+    def test_context_invalid_role(self, seeded_dir):
+        result = runner.invoke(app, ["context", "nonexistent"])
+        assert result.exit_code != 0
+        assert "not found" in result.output
+
+    def test_context_architecture_role(self, seeded_dir):
+        result = runner.invoke(app, ["context", "architecture", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["role"] == "architecture"
+        assert data["facts_loaded"] > 0
+
+    def test_context_no_draft_in_output(self, seeded_dir):
+        """Draft facts should never appear in context assembly."""
+        result = runner.invoke(app, ["context", "planning", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        for fact in data["facts"]:
+            assert fact["status"] != "Draft"
+
+    def test_context_no_deprecated_in_output(self, seeded_dir):
+        """Deprecated facts should not appear in context."""
+        # First deprecate a fact
+        runner.invoke(app, ["fact", "deprecate", "ADR-01", "--reason", "testing"])
+
+        result = runner.invoke(app, ["context", "planning", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        codes = [f["code"] for f in data["facts"]]
+        assert "ADR-01" not in codes
+
+    def test_context_confirmed_before_provisional(self, seeded_dir):
+        """Confirmed facts should be listed before Provisional."""
+        result = runner.invoke(app, ["context", "planning", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+
+        seen_provisional = False
+        for fact in data["facts"]:
+            if fact["confidence"] == "Provisional":
+                seen_provisional = True
+            if fact["confidence"] == "Confirmed" and seen_provisional:
+                pytest.fail("Confirmed fact appeared after Provisional")
+
+    def test_context_ref_pointers_present(self, seeded_dir):
+        """With budget, ref_pointers should include excluded facts."""
+        result = runner.invoke(
+            app, ["context", "planning", "--budget", "200", "--json"]
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        # Small budget should leave some facts unloaded
+        if data["budget_exhausted"]:
+            assert len(data["ref_pointers"]) > 0
+
+    def test_context_json_includes_version(self, seeded_dir):
+        """Gap 4: Every fact in JSON output must include version for audit (DES-08)."""
+        result = runner.invoke(app, ["context", "planning", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        for fact in data["facts"]:
+            assert "version" in fact
+            assert isinstance(fact["version"], int)
+            assert fact["version"] >= 1

--- a/tests/test_context_service.py
+++ b/tests/test_context_service.py
@@ -1,0 +1,484 @@
+"""Tests for context assembly service."""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from lattice_lens.models import FactConfidence, FactLayer, FactStatus
+from lattice_lens.services.context_service import (
+    ContextResult,
+    assemble_context,
+    estimate_fact_tokens,
+    estimate_tokens,
+)
+from lattice_lens.store.index import FactIndex
+from tests.conftest import make_fact
+
+
+def _build_index(facts: list) -> FactIndex:
+    """Build a FactIndex from a list of facts without writing to disk."""
+    idx = FactIndex()
+    for f in facts:
+        idx._add(f)
+    return idx
+
+
+class TestTokenEstimation:
+    def test_estimate_tokens_basic(self):
+        # ~4 chars per token
+        assert estimate_tokens("a" * 100) == 25
+        assert estimate_tokens("a" * 4) == 1
+        assert estimate_tokens("") == 1  # min 1
+
+    def test_estimate_fact_tokens(self):
+        fact = make_fact(fact="x" * 400)
+        tokens = estimate_fact_tokens(fact)
+        assert tokens > 100  # 400 chars of text alone = 100 tokens
+        assert tokens < 200  # metadata adds some, but not too much
+
+
+class TestContextAssembly:
+    """Test the assemble_context function."""
+
+    def _make_role_template(self, **overrides):
+        defaults = {
+            "name": "Test Agent",
+            "description": "Test role",
+            "query": {
+                "layers": ["WHY"],
+                "types": ["Architecture Decision Record"],
+                "tags": ["architecture"],
+                "max_facts": 50,
+                "extra": [],
+            },
+        }
+        defaults.update(overrides)
+        return defaults
+
+    def test_basic_assembly(self):
+        """Facts matching role query are loaded."""
+        facts = [
+            make_fact(code="ADR-01", status=FactStatus.ACTIVE, tags=["architecture", "test"]),
+            make_fact(code="ADR-02", status=FactStatus.ACTIVE, tags=["architecture", "test"]),
+        ]
+        index = _build_index(facts)
+        template = self._make_role_template()
+
+        result = assemble_context(index, "test", template)
+        assert len(result.loaded_facts) == 2
+
+    def test_draft_excluded(self):
+        """Draft facts are never included in context assembly."""
+        facts = [
+            make_fact(code="ADR-01", status=FactStatus.ACTIVE, tags=["architecture", "test"]),
+            make_fact(code="ADR-02", status=FactStatus.DRAFT, tags=["architecture", "test"]),
+        ]
+        index = _build_index(facts)
+        template = self._make_role_template()
+
+        result = assemble_context(index, "test", template)
+        assert len(result.loaded_facts) == 1
+        assert result.loaded_facts[0].code == "ADR-01"
+
+    def test_deprecated_excluded(self):
+        """Deprecated facts are never included."""
+        facts = [
+            make_fact(code="ADR-01", status=FactStatus.ACTIVE, tags=["architecture", "test"]),
+            make_fact(code="ADR-02", status=FactStatus.DEPRECATED, tags=["architecture", "test"]),
+        ]
+        index = _build_index(facts)
+        template = self._make_role_template()
+
+        result = assemble_context(index, "test", template)
+        assert len(result.loaded_facts) == 1
+
+    def test_superseded_excluded(self):
+        """Superseded facts are never included."""
+        facts = [
+            make_fact(code="ADR-01", status=FactStatus.ACTIVE, tags=["architecture", "test"]),
+            make_fact(
+                code="ADR-02",
+                status=FactStatus.SUPERSEDED,
+                superseded_by="ADR-03",
+                tags=["architecture", "test"],
+            ),
+        ]
+        index = _build_index(facts)
+        template = self._make_role_template()
+
+        result = assemble_context(index, "test", template)
+        assert len(result.loaded_facts) == 1
+
+    def test_under_review_included_as_provisional(self):
+        """Under Review facts are included with Provisional confidence."""
+        facts = [
+            make_fact(
+                code="ADR-01",
+                status=FactStatus.UNDER_REVIEW,
+                confidence=FactConfidence.PROVISIONAL,
+                tags=["architecture", "test"],
+            ),
+        ]
+        index = _build_index(facts)
+        template = self._make_role_template()
+
+        result = assemble_context(index, "test", template)
+        assert len(result.loaded_facts) == 1
+        assert result.loaded_facts[0].confidence == FactConfidence.PROVISIONAL
+
+    def test_priority_loading_confirmed_first(self):
+        """Confirmed facts load before Provisional facts."""
+        facts = [
+            make_fact(
+                code="ADR-01",
+                status=FactStatus.ACTIVE,
+                confidence=FactConfidence.PROVISIONAL,
+                tags=["architecture", "test"],
+            ),
+            make_fact(
+                code="ADR-02",
+                status=FactStatus.ACTIVE,
+                confidence=FactConfidence.CONFIRMED,
+                tags=["architecture", "test"],
+            ),
+        ]
+        index = _build_index(facts)
+        template = self._make_role_template()
+
+        result = assemble_context(index, "test", template)
+        assert len(result.loaded_facts) == 2
+        # Confirmed should come first
+        assert result.loaded_facts[0].confidence == FactConfidence.CONFIRMED
+        assert result.loaded_facts[1].confidence == FactConfidence.PROVISIONAL
+
+    def test_tag_match_score_sorting(self):
+        """Within same confidence tier, facts with more tag matches rank higher."""
+        facts = [
+            make_fact(
+                code="ADR-01",
+                status=FactStatus.ACTIVE,
+                tags=["scaling", "test"],  # no match with role tags
+            ),
+            make_fact(
+                code="ADR-02",
+                status=FactStatus.ACTIVE,
+                tags=["architecture", "test"],  # 1 match
+            ),
+        ]
+        index = _build_index(facts)
+        template = self._make_role_template()
+
+        result = assemble_context(index, "test", template)
+        assert result.loaded_facts[0].code == "ADR-02"  # higher tag match
+        assert result.loaded_facts[1].code == "ADR-01"
+
+    def test_token_budget_respected(self):
+        """Budget limits how many facts are loaded."""
+        facts = [
+            make_fact(code=f"ADR-{i:02d}", status=FactStatus.ACTIVE, tags=["architecture", "test"])
+            for i in range(1, 11)
+        ]
+        index = _build_index(facts)
+        template = self._make_role_template()
+
+        # Very small budget — should only load a few facts
+        result = assemble_context(index, "test", template, budget=200)
+        assert len(result.loaded_facts) < 10
+        assert result.budget_exhausted is True
+        assert result.total_tokens <= 200
+
+    def test_no_budget_loads_all(self):
+        """Without budget, all matching facts are loaded."""
+        facts = [
+            make_fact(code=f"ADR-{i:02d}", status=FactStatus.ACTIVE, tags=["architecture", "test"])
+            for i in range(1, 6)
+        ]
+        index = _build_index(facts)
+        template = self._make_role_template()
+
+        result = assemble_context(index, "test", template)
+        assert len(result.loaded_facts) == 5
+        assert result.budget_exhausted is False
+
+    def test_max_facts_from_template(self):
+        """max_facts in role template limits fact count."""
+        facts = [
+            make_fact(code=f"ADR-{i:02d}", status=FactStatus.ACTIVE, tags=["architecture", "test"])
+            for i in range(1, 11)
+        ]
+        index = _build_index(facts)
+        template = self._make_role_template(
+            query={
+                "layers": ["WHY"],
+                "types": ["Architecture Decision Record"],
+                "tags": ["architecture"],
+                "max_facts": 3,
+                "extra": [],
+            }
+        )
+
+        result = assemble_context(index, "test", template)
+        assert len(result.loaded_facts) == 3
+
+    def test_ref_pointers_for_excluded(self):
+        """Facts cut by budget appear in ref_pointers."""
+        facts = [
+            make_fact(code="ADR-01", status=FactStatus.ACTIVE, tags=["architecture", "test"]),
+            make_fact(code="ADR-02", status=FactStatus.ACTIVE, tags=["architecture", "test"]),
+            make_fact(code="ADR-03", status=FactStatus.ACTIVE, tags=["architecture", "test"]),
+        ]
+        index = _build_index(facts)
+        template = self._make_role_template(
+            query={
+                "layers": ["WHY"],
+                "types": ["Architecture Decision Record"],
+                "tags": ["architecture"],
+                "max_facts": 1,
+                "extra": [],
+            }
+        )
+
+        result = assemble_context(index, "test", template)
+        assert len(result.loaded_facts) == 1
+        assert len(result.ref_pointers) == 2  # 2 excluded facts
+
+    def test_ref_pointers_from_loaded_refs(self):
+        """Refs from loaded facts that point outside loaded set appear in pointers."""
+        risk_fact = make_fact(
+            code="RISK-01",
+            layer=FactLayer.GUARDRAILS,
+            type="Risk Assessment Finding",
+            status=FactStatus.ACTIVE,
+            tags=["risk", "test"],
+        )
+        adr_fact = make_fact(
+            code="ADR-01",
+            status=FactStatus.ACTIVE,
+            tags=["architecture", "test"],
+            refs=["RISK-01"],
+        )
+        index = _build_index([risk_fact, adr_fact])
+        template = self._make_role_template()
+
+        result = assemble_context(index, "test", template)
+        # Only ADR-01 should be loaded (RISK-01 doesn't match WHY/ADR query)
+        assert len(result.loaded_facts) == 1
+        assert result.loaded_facts[0].code == "ADR-01"
+        # RISK-01 should appear in ref_pointers
+        assert any("RISK-01" in ptr for ptr in result.ref_pointers)
+
+    def test_extra_rules_in_template(self):
+        """Extra rules in role template expand the query."""
+        adr_fact = make_fact(code="ADR-01", status=FactStatus.ACTIVE, tags=["architecture", "test"])
+        aup_fact = make_fact(
+            code="AUP-01",
+            layer=FactLayer.GUARDRAILS,
+            type="Acceptable Use Policy Rule",
+            status=FactStatus.ACTIVE,
+            tags=["governance", "test"],
+        )
+        index = _build_index([adr_fact, aup_fact])
+        template = self._make_role_template(
+            query={
+                "layers": ["WHY"],
+                "types": ["Architecture Decision Record"],
+                "tags": ["architecture"],
+                "max_facts": 50,
+                "extra": [{"layer": "GUARDRAILS", "types": ["Acceptable Use Policy Rule"]}],
+            }
+        )
+
+        result = assemble_context(index, "test", template)
+        codes = [f.code for f in result.loaded_facts]
+        assert "ADR-01" in codes
+        assert "AUP-01" in codes
+
+    def test_layer_mismatch_excluded(self):
+        """Facts that don't match the role's layer query are excluded."""
+        run_fact = make_fact(
+            code="RUN-01",
+            layer=FactLayer.HOW,
+            type="Runbook Procedure",
+            status=FactStatus.ACTIVE,
+            tags=["operations", "test"],
+        )
+        index = _build_index([run_fact])
+        template = self._make_role_template()
+
+        result = assemble_context(index, "test", template)
+        assert len(result.loaded_facts) == 0
+
+    def test_empty_index(self):
+        """Empty index yields empty context."""
+        index = _build_index([])
+        template = self._make_role_template()
+
+        result = assemble_context(index, "test", template)
+        assert len(result.loaded_facts) == 0
+        assert result.total_tokens == 0
+
+
+class TestContextResult:
+    """Test ContextResult rendering."""
+
+    def test_render_text(self):
+        fact = make_fact(code="ADR-01", tags=["architecture", "test"])
+        result = ContextResult(
+            role="test",
+            loaded_facts=[fact],
+            total_tokens=100,
+        )
+        text = result.render_text()
+        assert "# Context for role: test" in text
+        assert "ADR-01" in text
+        assert fact.fact in text
+
+    def test_render_text_with_pointers(self):
+        result = ContextResult(
+            role="test",
+            ref_pointers=["RISK-01 (GUARDRAILS/Risk Assessment Finding)"],
+        )
+        text = result.render_text()
+        assert "Additional facts" in text
+        assert "RISK-01" in text
+
+    def test_to_dict(self):
+        fact = make_fact(code="ADR-01", tags=["architecture", "test"])
+        result = ContextResult(
+            role="test",
+            loaded_facts=[fact],
+            total_tokens=100,
+            budget=500,
+        )
+        d = result.to_dict()
+        assert d["role"] == "test"
+        assert d["facts_loaded"] == 1
+        assert d["total_tokens"] == 100
+        assert d["budget"] == 500
+        assert len(d["facts"]) == 1
+        assert d["facts"][0]["code"] == "ADR-01"
+        assert "tokens" in d["facts"][0]
+
+    def test_to_dict_includes_version(self):
+        """Gap 4: version field must be present for audit reproducibility (DES-08)."""
+        fact = make_fact(code="ADR-01", tags=["architecture", "test"], version=3)
+        result = ContextResult(
+            role="test",
+            loaded_facts=[fact],
+            total_tokens=100,
+        )
+        d = result.to_dict()
+        assert d["facts"][0]["version"] == 3
+
+    def test_render_text_includes_version(self):
+        """Version should appear in text rendering too."""
+        fact = make_fact(code="ADR-01", tags=["architecture", "test"], version=5)
+        result = ContextResult(role="test", loaded_facts=[fact], total_tokens=100)
+        text = result.render_text()
+        assert "ADR-01 v5" in text
+
+
+class TestStaleDowngrade:
+    """Gap 3: Stale facts (past review_by) downgraded to Provisional tier per DG-06."""
+
+    def _make_role_template(self):
+        return {
+            "name": "Test Agent",
+            "query": {
+                "layers": ["WHY"],
+                "types": ["Architecture Decision Record"],
+                "tags": ["architecture"],
+                "max_facts": 50,
+                "extra": [],
+            },
+        }
+
+    def test_stale_confirmed_demoted_to_provisional_tier(self):
+        """A stale Confirmed fact should load after non-stale Confirmed facts."""
+        stale = make_fact(
+            code="ADR-01",
+            status=FactStatus.ACTIVE,
+            confidence=FactConfidence.CONFIRMED,
+            tags=["architecture", "test"],
+            review_by=date(2024, 1, 1),  # Well past
+        )
+        fresh = make_fact(
+            code="ADR-02",
+            status=FactStatus.ACTIVE,
+            confidence=FactConfidence.CONFIRMED,
+            tags=["architecture", "test"],
+        )
+        index = _build_index([stale, fresh])
+        template = self._make_role_template()
+
+        result = assemble_context(index, "test", template)
+        assert len(result.loaded_facts) == 2
+        # Fresh Confirmed should come first, stale should be demoted to Provisional tier
+        assert result.loaded_facts[0].code == "ADR-02"
+        assert result.loaded_facts[1].code == "ADR-01"
+
+    def test_stale_fact_behind_fresh_provisional(self):
+        """A stale Confirmed fact loads in the Provisional tier, alongside Provisional facts."""
+        stale_confirmed = make_fact(
+            code="ADR-01",
+            status=FactStatus.ACTIVE,
+            confidence=FactConfidence.CONFIRMED,
+            tags=["architecture", "test"],
+            review_by=date(2024, 1, 1),
+        )
+        fresh_provisional = make_fact(
+            code="ADR-02",
+            status=FactStatus.ACTIVE,
+            confidence=FactConfidence.PROVISIONAL,
+            tags=["architecture", "test"],
+        )
+        fresh_confirmed = make_fact(
+            code="ADR-03",
+            status=FactStatus.ACTIVE,
+            confidence=FactConfidence.CONFIRMED,
+            tags=["architecture", "test"],
+        )
+        index = _build_index([stale_confirmed, fresh_provisional, fresh_confirmed])
+        template = self._make_role_template()
+
+        result = assemble_context(index, "test", template)
+        codes = [f.code for f in result.loaded_facts]
+        # Fresh Confirmed first, then Provisional tier (stale + provisional)
+        assert codes[0] == "ADR-03"
+        assert "ADR-01" in codes[1:]
+        assert "ADR-02" in codes[1:]
+
+    def test_non_stale_fact_not_demoted(self):
+        """Facts with future review_by stay in Confirmed tier."""
+        fresh = make_fact(
+            code="ADR-01",
+            status=FactStatus.ACTIVE,
+            confidence=FactConfidence.CONFIRMED,
+            tags=["architecture", "test"],
+            review_by=date(2099, 12, 31),
+        )
+        index = _build_index([fresh])
+        template = self._make_role_template()
+
+        result = assemble_context(index, "test", template)
+        assert len(result.loaded_facts) == 1
+        # Still treated as Confirmed (not demoted)
+        assert result.loaded_facts[0].confidence == FactConfidence.CONFIRMED
+
+    def test_stale_still_loads_not_excluded(self):
+        """Stale facts are demoted, not excluded. They still appear in context."""
+        stale = make_fact(
+            code="ADR-01",
+            status=FactStatus.ACTIVE,
+            confidence=FactConfidence.CONFIRMED,
+            tags=["architecture", "test"],
+            review_by=date(2024, 1, 1),
+        )
+        index = _build_index([stale])
+        template = self._make_role_template()
+
+        result = assemble_context(index, "test", template)
+        assert len(result.loaded_facts) == 1  # Still loaded, just in lower tier

--- a/tests/test_evaluate_cli.py
+++ b/tests/test_evaluate_cli.py
@@ -1,0 +1,157 @@
+"""CLI integration tests for lattice evaluate command."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from lattice_lens.cli.main import app
+from lattice_lens.config import LATTICE_DIR
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def cli_dir(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+@pytest.fixture
+def initialized_dir(cli_dir: Path):
+    result = runner.invoke(app, ["init"])
+    assert result.exit_code == 0
+    return cli_dir
+
+
+@pytest.fixture
+def seeded_dir(initialized_dir: Path):
+    seed_src = Path(__file__).resolve().parent.parent / "seed"
+    seed_dst = initialized_dir / "seed"
+    if seed_src.exists():
+        shutil.copytree(seed_src, seed_dst, dirs_exist_ok=True)
+    result = runner.invoke(app, ["seed"])
+    assert result.exit_code == 0
+    return initialized_dir
+
+
+class TestEvaluateCommand:
+    def test_evaluate_no_lattice_silent(self, cli_dir: Path):
+        """No .lattice/ directory = silent no-op (exit 0, no output)."""
+        result = runner.invoke(app, ["evaluate"])
+        assert result.exit_code == 0
+        assert result.output.strip() == ""
+
+    def test_evaluate_with_lattice_produces_briefing(self, seeded_dir: Path):
+        """With seeded lattice, should output governance briefing."""
+        result = runner.invoke(app, ["evaluate"])
+        assert result.exit_code == 0
+        assert "Governance Briefing" in result.output
+        assert "Mandatory Rules" in result.output
+
+    def test_evaluate_includes_guardrail_codes(self, seeded_dir: Path):
+        """Active GUARDRAILS facts should appear in the briefing."""
+        result = runner.invoke(app, ["evaluate"])
+        assert result.exit_code == 0
+        # Seeded lattice has AUP-* and DG-* facts
+        assert "AUP-" in result.output
+
+    def test_evaluate_includes_knowledge_section(self, seeded_dir: Path):
+        """The knowledge discovery section should list available facts."""
+        result = runner.invoke(app, ["evaluate"])
+        assert result.exit_code == 0
+        assert "Project Knowledge Available" in result.output
+        assert "WHY layer" in result.output
+
+    def test_evaluate_includes_role_commands(self, seeded_dir: Path):
+        """Role context commands should be suggested."""
+        result = runner.invoke(app, ["evaluate"])
+        assert result.exit_code == 0
+        assert "lattice context" in result.output
+
+    def test_evaluate_json_output(self, seeded_dir: Path):
+        """JSON output should have all expected fields."""
+        result = runner.invoke(app, ["evaluate", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["lattice_found"] is True
+        assert data["guardrails_count"] > 0
+        assert isinstance(data["guardrails"], list)
+        assert isinstance(data["knowledge_summary"], dict)
+        assert isinstance(data["available_roles"], list)
+
+    def test_evaluate_json_no_lattice(self, cli_dir: Path):
+        """JSON output without lattice should indicate not found."""
+        result = runner.invoke(app, ["evaluate", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["lattice_found"] is False
+        assert data["guardrails_count"] == 0
+
+    def test_evaluate_only_guardrails_in_rules(self, seeded_dir: Path):
+        """Only GUARDRAILS-layer facts in the guardrails list."""
+        result = runner.invoke(app, ["evaluate", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        guardrail_prefixes = {"AUP", "DG", "RISK", "MC", "COMP"}
+        for fact in data["guardrails"]:
+            prefix = fact["code"].split("-")[0]
+            assert prefix in guardrail_prefixes, (
+                f"Non-GUARDRAILS fact {fact['code']} in guardrails list"
+            )
+
+    def test_evaluate_no_draft_in_output(self, seeded_dir: Path):
+        """Draft guardrails should not appear."""
+        result = runner.invoke(app, ["evaluate", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        # All guardrails should be Active (list_facts filters by status)
+        for fact in data["guardrails"]:
+            assert fact.get("confidence") in ("Confirmed", "Provisional", "Assumed")
+
+    def test_evaluate_knowledge_summary_has_layers(self, seeded_dir: Path):
+        """knowledge_summary should count WHY and HOW facts by type."""
+        result = runner.invoke(app, ["evaluate", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        ks = data["knowledge_summary"]
+        # Seeded lattice has WHY-layer facts (ADRs, PRDs, etc.)
+        assert "WHY" in ks
+        assert sum(ks["WHY"].values()) > 0
+
+    def test_evaluate_available_roles_populated(self, seeded_dir: Path):
+        """available_roles should list role template names."""
+        result = runner.invoke(app, ["evaluate", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert len(data["available_roles"]) > 0
+        # Seeded lattice has planning, architecture, implementation, qa, deploy
+        assert "planning" in data["available_roles"]
+
+    def test_evaluate_with_path_flag(self, seeded_dir: Path):
+        """--path flag overrides cwd discovery."""
+        result = runner.invoke(
+            app, ["evaluate", "--path", str(seeded_dir), "--json"]
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["lattice_found"] is True
+
+    def test_evaluate_json_guardrails_have_version(self, seeded_dir: Path):
+        """Each guardrail in JSON output must include version."""
+        result = runner.invoke(app, ["evaluate", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        for fact in data["guardrails"]:
+            assert "version" in fact
+            assert isinstance(fact["version"], int)
+
+    def test_evaluate_footer_in_text_output(self, seeded_dir: Path):
+        """Text output should include a summary footer."""
+        result = runner.invoke(app, ["evaluate"])
+        assert result.exit_code == 0
+        assert "Source: .lattice/" in result.output

--- a/tests/test_evaluate_service.py
+++ b/tests/test_evaluate_service.py
@@ -1,0 +1,444 @@
+"""Tests for governance evaluation service."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from lattice_lens.models import Fact, FactConfidence, FactLayer, FactStatus
+from lattice_lens.services.evaluate_service import (
+    EvaluationResult,
+    HookInput,
+    evaluate_governance,
+    parse_hook_input,
+)
+from tests.conftest import make_fact
+
+
+# ---------------------------------------------------------------------------
+# parse_hook_input
+# ---------------------------------------------------------------------------
+
+
+class TestParseHookInput:
+    def test_valid_json(self):
+        data = (
+            '{"session_id": "abc", "cwd": "/tmp/proj", '
+            '"hook_event_name": "UserPromptSubmit", "prompt": "fix bug"}'
+        )
+        result = parse_hook_input(data)
+        assert result is not None
+        assert result.session_id == "abc"
+        assert result.cwd == "/tmp/proj"
+        assert result.hook_event_name == "UserPromptSubmit"
+        assert result.prompt == "fix bug"
+
+    def test_empty_string(self):
+        assert parse_hook_input("") is None
+
+    def test_whitespace_only(self):
+        assert parse_hook_input("   \n  ") is None
+
+    def test_invalid_json(self):
+        assert parse_hook_input("not json at all") is None
+
+    def test_partial_fields(self):
+        result = parse_hook_input('{"cwd": "/tmp"}')
+        assert result is not None
+        assert result.cwd == "/tmp"
+        assert result.session_id == ""
+        assert result.prompt == ""
+
+    def test_none_input(self):
+        assert parse_hook_input(None) is None
+
+
+# ---------------------------------------------------------------------------
+# evaluate_governance
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluateGovernance:
+    def test_no_lattice_returns_empty(self, tmp_path: Path):
+        result = evaluate_governance(start_path=tmp_path)
+        assert result.lattice_found is False
+        assert result.guardrails == []
+        assert result.has_governance is False
+        assert result.knowledge_summary == {}
+        assert result.available_roles == []
+
+    def test_empty_lattice_returns_no_facts(self, tmp_lattice: Path):
+        result = evaluate_governance(start_path=tmp_lattice.parent)
+        assert result.lattice_found is True
+        assert result.guardrails == []
+        assert result.has_governance is False
+
+    def test_loads_active_guardrails(self, yaml_store):
+        aup = make_fact(
+            code="AUP-01",
+            layer=FactLayer.GUARDRAILS,
+            type="Acceptable Use Policy Rule",
+            status=FactStatus.ACTIVE,
+            tags=["policy", "test"],
+        )
+        dg = make_fact(
+            code="DG-01",
+            layer=FactLayer.GUARDRAILS,
+            type="Data Governance Rule",
+            status=FactStatus.ACTIVE,
+            tags=["governance", "test"],
+        )
+        yaml_store.create(aup)
+        yaml_store.create(dg)
+
+        result = evaluate_governance(start_path=yaml_store.root.parent)
+        assert result.lattice_found is True
+        assert result.has_governance is True
+        assert len(result.guardrails) == 2
+
+    def test_excludes_draft_guardrails(self, yaml_store):
+        active = make_fact(
+            code="AUP-01",
+            layer=FactLayer.GUARDRAILS,
+            type="Acceptable Use Policy Rule",
+            status=FactStatus.ACTIVE,
+            tags=["policy", "test"],
+        )
+        draft = make_fact(
+            code="AUP-02",
+            layer=FactLayer.GUARDRAILS,
+            type="Acceptable Use Policy Rule",
+            status=FactStatus.DRAFT,
+            tags=["policy", "test"],
+        )
+        yaml_store.create(active)
+        yaml_store.create(draft)
+
+        result = evaluate_governance(start_path=yaml_store.root.parent)
+        assert len(result.guardrails) == 1
+        assert result.guardrails[0].code == "AUP-01"
+
+    def test_excludes_deprecated_guardrails(self, yaml_store):
+        active = make_fact(
+            code="AUP-01",
+            layer=FactLayer.GUARDRAILS,
+            type="Acceptable Use Policy Rule",
+            status=FactStatus.ACTIVE,
+            tags=["policy", "test"],
+        )
+        deprecated = make_fact(
+            code="AUP-02",
+            layer=FactLayer.GUARDRAILS,
+            type="Acceptable Use Policy Rule",
+            status=FactStatus.DEPRECATED,
+            tags=["policy", "test"],
+        )
+        yaml_store.create(active)
+        yaml_store.create(deprecated)
+
+        result = evaluate_governance(start_path=yaml_store.root.parent)
+        assert len(result.guardrails) == 1
+
+    def test_excludes_non_guardrails_from_rules(self, yaml_store):
+        aup = make_fact(
+            code="AUP-01",
+            layer=FactLayer.GUARDRAILS,
+            type="Acceptable Use Policy Rule",
+            status=FactStatus.ACTIVE,
+            tags=["policy", "test"],
+        )
+        adr = make_fact(
+            code="ADR-01",
+            layer=FactLayer.WHY,
+            type="Architecture Decision Record",
+            status=FactStatus.ACTIVE,
+            tags=["architecture", "test"],
+        )
+        yaml_store.create(aup)
+        yaml_store.create(adr)
+
+        result = evaluate_governance(start_path=yaml_store.root.parent)
+        # Only GUARDRAILS in the rules list
+        assert len(result.guardrails) == 1
+        assert result.guardrails[0].code == "AUP-01"
+
+    def test_confirmed_before_provisional(self, yaml_store):
+        provisional = make_fact(
+            code="AUP-01",
+            layer=FactLayer.GUARDRAILS,
+            type="Acceptable Use Policy Rule",
+            status=FactStatus.ACTIVE,
+            confidence=FactConfidence.PROVISIONAL,
+            tags=["policy", "test"],
+        )
+        confirmed = make_fact(
+            code="AUP-02",
+            layer=FactLayer.GUARDRAILS,
+            type="Acceptable Use Policy Rule",
+            status=FactStatus.ACTIVE,
+            confidence=FactConfidence.CONFIRMED,
+            tags=["policy", "test"],
+        )
+        yaml_store.create(provisional)
+        yaml_store.create(confirmed)
+
+        result = evaluate_governance(start_path=yaml_store.root.parent)
+        assert result.guardrails[0].code == "AUP-02"  # Confirmed first
+        assert result.guardrails[1].code == "AUP-01"
+
+    def test_token_estimation_positive(self, yaml_store):
+        aup = make_fact(
+            code="AUP-01",
+            layer=FactLayer.GUARDRAILS,
+            type="Acceptable Use Policy Rule",
+            status=FactStatus.ACTIVE,
+            tags=["policy", "test"],
+        )
+        yaml_store.create(aup)
+
+        result = evaluate_governance(start_path=yaml_store.root.parent)
+        assert result.total_tokens > 0
+
+    def test_knowledge_summary_counts_why_how(self, yaml_store):
+        """WHY and HOW facts should appear in knowledge_summary."""
+        adr = make_fact(
+            code="ADR-01",
+            layer=FactLayer.WHY,
+            type="Architecture Decision Record",
+            status=FactStatus.ACTIVE,
+            tags=["architecture", "test"],
+        )
+        sp = make_fact(
+            code="SP-01",
+            layer=FactLayer.HOW,
+            type="Solution Pattern",
+            status=FactStatus.ACTIVE,
+            tags=["pattern", "test"],
+        )
+        yaml_store.create(adr)
+        yaml_store.create(sp)
+
+        result = evaluate_governance(start_path=yaml_store.root.parent)
+        assert "WHY" in result.knowledge_summary
+        assert result.knowledge_summary["WHY"]["Architecture Decision Record"] == 1
+        assert "HOW" in result.knowledge_summary
+        assert result.knowledge_summary["HOW"]["Solution Pattern"] == 1
+
+    def test_knowledge_summary_excludes_draft_facts(self, yaml_store):
+        """Draft WHY/HOW facts should not be counted in the summary."""
+        active_adr = make_fact(
+            code="ADR-01",
+            layer=FactLayer.WHY,
+            type="Architecture Decision Record",
+            status=FactStatus.ACTIVE,
+            tags=["architecture", "test"],
+        )
+        draft_adr = make_fact(
+            code="ADR-02",
+            layer=FactLayer.WHY,
+            type="Architecture Decision Record",
+            status=FactStatus.DRAFT,
+            tags=["architecture", "test"],
+        )
+        yaml_store.create(active_adr)
+        yaml_store.create(draft_adr)
+
+        result = evaluate_governance(start_path=yaml_store.root.parent)
+        assert result.knowledge_summary["WHY"]["Architecture Decision Record"] == 1
+
+    def test_knowledge_summary_excludes_guardrails(self, yaml_store):
+        """GUARDRAILS facts should NOT appear in knowledge_summary."""
+        aup = make_fact(
+            code="AUP-01",
+            layer=FactLayer.GUARDRAILS,
+            type="Acceptable Use Policy Rule",
+            status=FactStatus.ACTIVE,
+            tags=["policy", "test"],
+        )
+        yaml_store.create(aup)
+
+        result = evaluate_governance(start_path=yaml_store.root.parent)
+        assert "GUARDRAILS" not in result.knowledge_summary
+
+    def test_available_roles_populated(self, yaml_store):
+        """Roles from .lattice/roles/ should appear in the result."""
+        from ruamel.yaml import YAML
+
+        yaml_rw = YAML()
+        roles_dir = yaml_store.root / "roles"
+        roles_dir.mkdir(exist_ok=True)
+        with open(roles_dir / "planning.yaml", "w") as f:
+            yaml_rw.dump(
+                {
+                    "name": "Planning Agent",
+                    "description": "Test",
+                    "query": {
+                        "layers": ["WHY"],
+                        "types": [],
+                        "tags": [],
+                        "max_facts": 10,
+                        "extra": [],
+                    },
+                },
+                f,
+            )
+
+        result = evaluate_governance(start_path=yaml_store.root.parent)
+        assert "planning" in result.available_roles
+
+    def test_available_roles_empty_when_no_roles_dir(self, yaml_store):
+        """No roles directory should yield an empty roles list."""
+        import shutil
+
+        roles_dir = yaml_store.root / "roles"
+        if roles_dir.exists():
+            shutil.rmtree(roles_dir)
+
+        result = evaluate_governance(start_path=yaml_store.root.parent)
+        assert result.available_roles == []
+
+
+# ---------------------------------------------------------------------------
+# EvaluationResult rendering
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluationResultRendering:
+    def test_render_briefing_with_guardrails(self):
+        fact = make_fact(
+            code="AUP-01",
+            layer=FactLayer.GUARDRAILS,
+            type="Acceptable Use Policy Rule",
+            tags=["policy", "test"],
+        )
+        result = EvaluationResult(
+            lattice_found=True,
+            guardrails=[fact],
+            total_tokens=50,
+        )
+        text = result.render_briefing()
+        assert "Governance Briefing" in text
+        assert "AUP-01" in text
+        assert "You MUST follow" in text
+        assert "Mandatory Rules" in text
+
+    def test_render_briefing_includes_conflict_directive(self):
+        """The briefing must tell the agent to raise conflicts before proceeding."""
+        fact = make_fact(
+            code="AUP-01",
+            layer=FactLayer.GUARDRAILS,
+            type="Acceptable Use Policy Rule",
+            tags=["policy", "test"],
+        )
+        result = EvaluationResult(
+            lattice_found=True,
+            guardrails=[fact],
+            total_tokens=50,
+        )
+        text = result.render_briefing()
+        assert "raise the conflict" in text
+        assert "cite the specific rule code" in text
+        assert "Ask the user" in text
+
+    def test_render_briefing_includes_knowledge_section(self):
+        result = EvaluationResult(
+            lattice_found=True,
+            guardrails=[],
+            knowledge_summary={
+                "WHY": {"Architecture Decision Record": 3},
+                "HOW": {"Solution Pattern": 2},
+            },
+            available_roles=["planning", "implementation"],
+        )
+        text = result.render_briefing()
+        assert "Project Knowledge Available" in text
+        assert "3 Architecture Decision Records" in text
+        assert "2 Solution Patterns" in text
+        assert "lattice context planning" in text
+        assert "lattice context implementation" in text
+
+    def test_render_briefing_includes_role_hints(self):
+        result = EvaluationResult(
+            lattice_found=True,
+            guardrails=[],
+            knowledge_summary={"WHY": {"Product Requirement": 1}},
+            available_roles=["architecture", "qa", "deploy"],
+        )
+        text = result.render_briefing()
+        assert "design decisions" in text
+        assert "testing/QA" in text
+        assert "deployment" in text
+
+    def test_render_briefing_empty_when_no_lattice(self):
+        result = EvaluationResult(lattice_found=False)
+        assert result.render_briefing() == ""
+
+    def test_render_briefing_empty_when_no_content(self):
+        result = EvaluationResult(lattice_found=True)
+        assert result.render_briefing() == ""
+
+    def test_render_briefing_singular_count(self):
+        result = EvaluationResult(
+            lattice_found=True,
+            knowledge_summary={"WHY": {"Product Requirement": 1}},
+        )
+        text = result.render_briefing()
+        assert "1 Product Requirement" in text
+        # Should NOT have trailing 's' for count=1
+        assert "1 Product Requirements" not in text
+
+    def test_to_dict_structure(self):
+        fact = make_fact(
+            code="AUP-01",
+            layer=FactLayer.GUARDRAILS,
+            type="Acceptable Use Policy Rule",
+            tags=["policy", "test"],
+        )
+        result = EvaluationResult(
+            lattice_found=True,
+            guardrails=[fact],
+            total_tokens=50,
+            lattice_root="/tmp/.lattice",
+            knowledge_summary={"WHY": {"Architecture Decision Record": 2}},
+            available_roles=["planning"],
+        )
+        d = result.to_dict()
+        assert d["lattice_found"] is True
+        assert d["guardrails_count"] == 1
+        assert d["guardrails"][0]["code"] == "AUP-01"
+        assert "version" in d["guardrails"][0]
+        assert d["knowledge_summary"]["WHY"]["Architecture Decision Record"] == 2
+        assert d["available_roles"] == ["planning"]
+
+    def test_to_dict_no_lattice(self):
+        result = EvaluationResult()
+        d = result.to_dict()
+        assert d["lattice_found"] is False
+        assert d["guardrails_count"] == 0
+        assert d["guardrails"] == []
+        assert d["knowledge_summary"] == {}
+        assert d["available_roles"] == []
+
+    def test_footer_includes_counts(self):
+        result = EvaluationResult(
+            lattice_found=True,
+            guardrails=[
+                make_fact(
+                    code="AUP-01",
+                    layer=FactLayer.GUARDRAILS,
+                    type="Acceptable Use Policy Rule",
+                    tags=["policy", "test"],
+                )
+            ],
+            knowledge_summary={
+                "WHY": {"Architecture Decision Record": 5},
+                "HOW": {"Solution Pattern": 3},
+            },
+            available_roles=["planning", "implementation"],
+        )
+        text = result.render_briefing()
+        assert "1 guardrails" in text
+        assert "5 WHY facts" in text
+        assert "3 HOW facts" in text
+        assert "2 roles" in text

--- a/tests/test_promote.py
+++ b/tests/test_promote.py
@@ -1,0 +1,250 @@
+"""Tests for the fact promote command and service logic."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from lattice_lens.cli.main import app
+from lattice_lens.config import FACTS_DIR, LATTICE_DIR
+from lattice_lens.models import FactConfidence, FactStatus
+from lattice_lens.services.fact_service import PROMOTION_TRANSITIONS, promote_fact
+from tests.conftest import make_fact
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def cli_dir(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+@pytest.fixture
+def initialized_dir(cli_dir: Path):
+    result = runner.invoke(app, ["init"])
+    assert result.exit_code == 0
+    return cli_dir
+
+
+@pytest.fixture
+def seeded_dir(initialized_dir: Path):
+    seed_src = Path(__file__).resolve().parent.parent / "seed"
+    seed_dst = initialized_dir / "seed"
+    if seed_src.exists():
+        shutil.copytree(seed_src, seed_dst, dirs_exist_ok=True)
+    result = runner.invoke(app, ["seed"])
+    assert result.exit_code == 0
+    return initialized_dir
+
+
+class TestPromoteService:
+    """Unit tests for promote_fact() business logic."""
+
+    def test_promote_draft_to_under_review(self, yaml_store):
+        fact = make_fact(code="ADR-99", status=FactStatus.DRAFT, confidence=FactConfidence.PROVISIONAL)
+        yaml_store.create(fact)
+
+        result = promote_fact(yaml_store, "ADR-99", "Ready for review")
+        assert result.status == FactStatus.UNDER_REVIEW
+        assert result.confidence == FactConfidence.PROVISIONAL
+        assert result.version == 2
+
+    def test_promote_under_review_to_active(self, yaml_store):
+        fact = make_fact(code="ADR-99", status=FactStatus.UNDER_REVIEW, confidence=FactConfidence.PROVISIONAL)
+        yaml_store.create(fact)
+
+        result = promote_fact(yaml_store, "ADR-99", "Reviewed and approved")
+        assert result.status == FactStatus.ACTIVE
+        assert result.confidence == FactConfidence.CONFIRMED
+        assert result.version == 2
+
+    def test_promote_active_raises(self, yaml_store):
+        fact = make_fact(code="ADR-99", status=FactStatus.ACTIVE)
+        yaml_store.create(fact)
+
+        with pytest.raises(ValueError, match="not promotable"):
+            promote_fact(yaml_store, "ADR-99", "Can't promote Active")
+
+    def test_promote_deprecated_raises(self, yaml_store):
+        fact = make_fact(code="ADR-99", status=FactStatus.DEPRECATED)
+        yaml_store.create(fact)
+
+        with pytest.raises(ValueError, match="not promotable"):
+            promote_fact(yaml_store, "ADR-99", "Can't promote Deprecated")
+
+    def test_promote_superseded_raises(self, yaml_store):
+        fact = make_fact(
+            code="ADR-99",
+            status=FactStatus.SUPERSEDED,
+            superseded_by="ADR-100",
+        )
+        yaml_store.create(fact)
+
+        with pytest.raises(ValueError, match="not promotable"):
+            promote_fact(yaml_store, "ADR-99", "Can't promote Superseded")
+
+    def test_promote_not_found(self, yaml_store):
+        with pytest.raises(FileNotFoundError):
+            promote_fact(yaml_store, "ADR-99", "Doesn't exist")
+
+    def test_promote_appends_changelog(self, yaml_store):
+        fact = make_fact(code="ADR-99", status=FactStatus.DRAFT)
+        yaml_store.create(fact)
+        promote_fact(yaml_store, "ADR-99", "Promoting")
+
+        changelog = yaml_store.history_dir / "changelog.jsonl"
+        lines = changelog.read_text().strip().split("\n")
+        last_entry = json.loads(lines[-1])
+        assert last_entry["action"] == "update"
+        assert last_entry["code"] == "ADR-99"
+        assert "Promoted" in last_entry["reason"]
+
+    def test_full_lifecycle_draft_to_active(self, yaml_store):
+        """Test the full Draft -> Under Review -> Active promotion path."""
+        fact = make_fact(code="ADR-99", status=FactStatus.DRAFT, confidence=FactConfidence.PROVISIONAL)
+        yaml_store.create(fact)
+
+        # Step 1: Draft -> Under Review
+        result = promote_fact(yaml_store, "ADR-99", "Step 1")
+        assert result.status == FactStatus.UNDER_REVIEW
+        assert result.version == 2
+
+        # Step 2: Under Review -> Active
+        result = promote_fact(yaml_store, "ADR-99", "Step 2")
+        assert result.status == FactStatus.ACTIVE
+        assert result.confidence == FactConfidence.CONFIRMED
+        assert result.version == 3
+
+        # Step 3: Active cannot be promoted further
+        with pytest.raises(ValueError, match="not promotable"):
+            promote_fact(yaml_store, "ADR-99", "Step 3")
+
+    def test_promotion_transitions_map(self):
+        """Verify the transition map is complete and correct."""
+        assert PROMOTION_TRANSITIONS[FactStatus.DRAFT] == FactStatus.UNDER_REVIEW
+        assert PROMOTION_TRANSITIONS[FactStatus.UNDER_REVIEW] == FactStatus.ACTIVE
+        assert FactStatus.ACTIVE not in PROMOTION_TRANSITIONS
+        assert FactStatus.DEPRECATED not in PROMOTION_TRANSITIONS
+        assert FactStatus.SUPERSEDED not in PROMOTION_TRANSITIONS
+
+
+class TestPromoteCLI:
+    """CLI integration tests for `lattice fact promote`."""
+
+    def test_promote_cli(self, seeded_dir):
+        # Create a Draft fact first
+        from ruamel.yaml import YAML
+
+        yaml_rw = YAML()
+        yaml_rw.default_flow_style = False
+        fact_data = {
+            "code": "ADR-99",
+            "layer": "WHY",
+            "type": "Architecture Decision Record",
+            "fact": "This is a test fact for promotion testing.",
+            "tags": ["test", "promotion"],
+            "status": "Draft",
+            "confidence": "Provisional",
+            "owner": "test-team",
+            "version": 1,
+            "refs": [],
+        }
+
+        facts_dir = seeded_dir / LATTICE_DIR / FACTS_DIR
+        with open(facts_dir / "ADR-99.yaml", "w") as f:
+            yaml_rw.dump(fact_data, f)
+
+        # Promote Draft -> Under Review
+        result = runner.invoke(
+            app, ["fact", "promote", "ADR-99", "--reason", "Ready for review"]
+        )
+        assert result.exit_code == 0
+        assert "Promoted" in result.output
+        assert "Under Review" in result.output
+
+        # Promote Under Review -> Active
+        result = runner.invoke(
+            app, ["fact", "promote", "ADR-99", "--reason", "Approved"]
+        )
+        assert result.exit_code == 0
+        assert "Active" in result.output
+
+    def test_promote_not_found_cli(self, seeded_dir):
+        result = runner.invoke(
+            app, ["fact", "promote", "NOPE-99", "--reason", "test"]
+        )
+        assert result.exit_code != 0
+        assert "not found" in result.output
+
+    def test_promote_active_fails_cli(self, seeded_dir):
+        result = runner.invoke(
+            app, ["fact", "promote", "ADR-01", "--reason", "test"]
+        )
+        assert result.exit_code != 0
+        assert "not promotable" in result.output
+
+    def test_promote_requires_reason(self, seeded_dir):
+        result = runner.invoke(app, ["fact", "promote", "ADR-01"])
+        assert result.exit_code != 0
+
+
+class TestLifecycleEnforcement:
+    """Tests for lifecycle bypass prevention (Gaps 1 & 2)."""
+
+    def test_add_from_file_warns_on_non_draft(self, seeded_dir):
+        """Gap 1: Importing a fact with status != Draft should emit a warning."""
+        from ruamel.yaml import YAML
+
+        yaml_rw = YAML()
+        yaml_rw.default_flow_style = False
+        fact_data = {
+            "code": "ADR-99",
+            "layer": "WHY",
+            "type": "Architecture Decision Record",
+            "fact": "This fact is imported with Active status bypassing lifecycle.",
+            "tags": ["test", "bypass"],
+            "status": "Active",
+            "confidence": "Confirmed",
+            "owner": "test-team",
+        }
+        import_file = seeded_dir / "import-active.yaml"
+        with open(import_file, "w") as f:
+            yaml_rw.dump(fact_data, f)
+
+        result = runner.invoke(app, ["fact", "add", "--from", str(import_file)])
+        assert result.exit_code == 0
+        # Should warn about non-Draft status
+        assert "AUP-08" in result.output
+        assert "Draft" in result.output
+        # But still creates the fact (warn, not block)
+        assert "Created" in result.output
+
+    def test_add_from_file_no_warning_for_draft(self, seeded_dir):
+        """Importing a Draft fact should not produce a warning."""
+        from ruamel.yaml import YAML
+
+        yaml_rw = YAML()
+        yaml_rw.default_flow_style = False
+        fact_data = {
+            "code": "ADR-99",
+            "layer": "WHY",
+            "type": "Architecture Decision Record",
+            "fact": "This fact is imported with Draft status, which is correct.",
+            "tags": ["test", "lifecycle"],
+            "status": "Draft",
+            "confidence": "Provisional",
+            "owner": "test-team",
+        }
+        import_file = seeded_dir / "import-draft.yaml"
+        with open(import_file, "w") as f:
+            yaml_rw.dump(fact_data, f)
+
+        result = runner.invoke(app, ["fact", "add", "--from", str(import_file)])
+        assert result.exit_code == 0
+        assert "AUP-08" not in result.output
+        assert "Created" in result.output


### PR DESCRIPTION
## Summary
- **Fact lifecycle commands** — `lattice fact promote` moves facts through Draft → Under Review → Active; `lattice fact edit` blocks promotion-via-edit and redirects to the promote command
- **Role-scoped context assembly** — `lattice context <role> [--budget N] [--json]` loads Confirmed-first, Provisional-if-budget-remains facts with REFS pointers for excluded facts
- **Governance hook** — `lattice evaluate` as a `UserPromptSubmit` hook injects active GUARDRAILS rules, conflict-raising directive, and knowledge discovery summary into every Claude Code prompt; silent no-op when no `.lattice/` exists
- **Dogfood setup** — `.claude/settings.json` configures the hook for this project; README documents full setup
- **Lattice updates** — AUP-08/PRD-03 promoted to Active, DG-04 updated to match actual `fact ls` defaults, RISK-07 added for per-prompt index rebuild overhead
- **197 tests passing** across 5 new test files (promote, context service/CLI, evaluate service/CLI)

## Test plan
- [x] All 197 tests pass (`python -m pytest tests/ -v`)
- [x] `lattice evaluate` produces governance briefing with all active GUARDRAILS
- [x] `lattice evaluate` is silent (exit 0, no output) when no `.lattice/` exists
- [x] `lattice context planning --budget 4000 --json` returns token-budgeted facts
- [x] `lattice fact promote` enforces Draft → Under Review → Active transitions
- [x] Governance hook successfully raises conflicts when asked to violate rules (tested live with AUP-01 deletion request)
- [x] RISK-07 imported as Draft per AUP-08 lifecycle rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)