### PR TITLE
Governance audit fixes + tag/type registry Draft facts

### DIFF
--- a/.lattice/facts/DES-09.yaml
+++ b/.lattice/facts/DES-09.yaml
@@ -1,0 +1,26 @@
+code: DES-09
+layer: WHY
+type: Design Proposal Decision
+fact: A centralized tag registry at .lattice/tags.yaml lists all tags in use 
+  across the lattice with usage counts and vocabulary category assignments. The 
+  registry is generated and refreshable via a lattice tags command — not 
+  hand-edited. Tags are case-insensitive (enforced by existing DG-02 
+  normalization) and deduplicated. The registry serves as the source of truth 
+  for the controlled vocabulary defined in DG-07, replacing the current 
+  documentation-only approach with a queryable, committable artifact.
+tags:
+- controlled-vocabulary
+- design-time
+- developer
+- tag-vocabulary
+status: Draft
+confidence: Confirmed
+version: 1
+refs:
+- DG-02
+- DG-07
+superseded_by:
+owner: architecture-team
+review_by:
+created_at: '2026-03-05T20:25:23.591955'
+updated_at: '2026-03-05T20:25:23.592067'

--- a/.lattice/facts/DES-10.yaml
+++ b/.lattice/facts/DES-10.yaml
@@ -1,0 +1,28 @@
+code: DES-10
+layer: WHY
+type: Design Proposal Decision
+fact: A type registry at .lattice/types.yaml defines the canonical type string 
+  for each code prefix. Every prefix in LAYER_PREFIXES maps to exactly one 
+  canonical type name (e.g., ADR -> Architecture Decision Record, RISK -> Risk 
+  Register Entry). The registry is the single source of truth for type naming. 
+  The lattice validate command warns when a fact uses a type string that does 
+  not match its prefix canonical type. Future enforcement may reject 
+  non-canonical types at write time. This addresses the RISK-03 finding that 
+  free-text type fields cause silent mismatches in role template queries.
+tags:
+- controlled-vocabulary
+- design-time
+- developer
+- type-registry
+status: Draft
+confidence: Confirmed
+version: 1
+refs:
+- RISK-03
+- ADR-05
+- DG-02
+superseded_by:
+owner: architecture-team
+review_by:
+created_at: '2026-03-05T20:27:26.933808'
+updated_at: '2026-03-05T20:27:26.933949'

--- a/.lattice/facts/DG-05.yaml
+++ b/.lattice/facts/DG-05.yaml
@@ -1,11 +1,12 @@
 code: DG-05
 layer: GUARDRAILS
 type: Data Governance Rule
-fact: The changelog at .lattice/changelog.jsonl uses JSON Lines format â€” one 
+fact: The changelog at .lattice/changelog.jsonl uses JSON Lines format — one 
   JSON object per line, append-only. Each entry records action (add, update, 
-  delete), fact code, timestamp, and a snapshot of the fact data. JSONL is 
-  streamable, grep-friendly, and avoids the need to parse an entire file for new
-  appends. The changelog is written by LatticeStore on every mutation.
+  delete), fact code, timestamp, and reason. JSONL is streamable, grep-friendly,
+  and avoids the need to parse an entire file for new appends. The changelog is 
+  written by LatticeStore on every mutation. Full fact state snapshots are not 
+  included — git history on the YAML files themselves serves that purpose.
 tags:
 - append-only
 - audit-trail
@@ -13,7 +14,7 @@ tags:
 - jsonl
 status: Active
 confidence: Confirmed
-version: 1
+version: 2
 refs:
 - ADR-06
 - DG-01
@@ -21,4 +22,4 @@ superseded_by:
 owner: architecture-team
 review_by: '2026-09-01'
 created_at: '2026-03-05T13:00:32.840045'
-updated_at: '2026-03-05T13:00:32.840075'
+updated_at: '2026-03-05T20:24:37.680067'

--- a/.lattice/facts/DG-09.yaml
+++ b/.lattice/facts/DG-09.yaml
@@ -1,0 +1,26 @@
+code: DG-09
+layer: GUARDRAILS
+type: Data Governance Rule
+fact: The tag registry at .lattice/tags.yaml is a generated artifact listing 
+  every tag in use with its count and vocabulary category (domain, concern, 
+  lifecycle, stakeholder, risk, or free). The lattice tags command rebuilds it 
+  from current facts. The lattice validate command warns when a free tag appears
+  in 3 or more facts, suggesting it be reviewed for inclusion in the controlled 
+  vocabulary. The registry file should be committed to git for team visibility.
+tags:
+- controlled-vocabulary
+- governance
+- tag-vocabulary
+- validation
+status: Draft
+confidence: Confirmed
+version: 1
+refs:
+- DES-09
+- DG-02
+- DG-07
+superseded_by:
+owner: architecture-team
+review_by:
+created_at: '2026-03-05T20:25:23.594981'
+updated_at: '2026-03-05T20:25:23.594982'

--- a/.lattice/facts/DG-10.yaml
+++ b/.lattice/facts/DG-10.yaml
@@ -1,0 +1,28 @@
+code: DG-10
+layer: GUARDRAILS
+type: Data Governance Rule
+fact: 'The type registry at .lattice/types.yaml maps each code prefix to its canonical
+  type string. The canonical types are: ADR -> Architecture Decision Record, PRD ->
+  Product Requirement, ETH -> Ethical Finding, DES -> Design Proposal Decision, MC
+  -> Model Card Entry, AUP -> Acceptable Use Policy Rule, RISK -> Risk Register Entry,
+  DG -> Data Governance Rule, COMP -> Compliance Rule, SP -> System Prompt Rule, API
+  -> API Specification, RUN -> Runbook Procedure, ML -> MLOps Rule, MON -> Monitoring
+  Rule. The lattice validate command reports type mismatches as warnings. Facts with
+  non-canonical types are still stored but flagged for correction.'
+tags:
+- controlled-vocabulary
+- governance
+- type-registry
+- validation
+status: Draft
+confidence: Confirmed
+version: 1
+refs:
+- DES-10
+- RISK-03
+- MC-01
+superseded_by:
+owner: architecture-team
+review_by:
+created_at: '2026-03-05T20:27:26.938135'
+updated_at: '2026-03-05T20:27:26.938137'

--- a/.lattice/facts/RISK-06.yaml
+++ b/.lattice/facts/RISK-06.yaml
@@ -13,9 +13,9 @@ tags:
 - risk
 - storage-tiers
 - thresholds
-status: Active
+status: Draft
 confidence: Confirmed
-version: 2
+version: 3
 refs:
 - DES-06
 - DES-02
@@ -24,4 +24,4 @@ superseded_by:
 owner: architecture-team
 review_by: '2026-09-01'
 created_at: '2026-03-05T13:06:56.192012'
-updated_at: '2026-03-05T18:11:06.976650'
+updated_at: '2026-03-05T20:24:50.879059'

--- a/.lattice/facts/SP-08.yaml
+++ b/.lattice/facts/SP-08.yaml
@@ -1,0 +1,25 @@
+code: SP-08
+layer: HOW
+type: System Prompt Rule
+fact: 'The lattice tags command lists all tags currently in use across the lattice,
+  sorted alphabetically, with usage counts and vocabulary category. Output formats:
+  Rich table (default) and JSON (--json). The lattice tags --rebuild flag regenerates
+  .lattice/tags.yaml from current facts. The command reads from the index and does
+  not require an API key or external service.'
+tags:
+- cli
+- controlled-vocabulary
+- developer
+- tag-vocabulary
+status: Draft
+confidence: Confirmed
+version: 1
+refs:
+- DES-09
+- DG-09
+- DG-02
+superseded_by:
+owner: architecture-team
+review_by:
+created_at: '2026-03-05T20:25:23.596832'
+updated_at: '2026-03-05T20:25:23.596833'

--- a/.lattice/facts/SP-09.yaml
+++ b/.lattice/facts/SP-09.yaml
@@ -1,0 +1,26 @@
+code: SP-09
+layer: HOW
+type: System Prompt Rule
+fact: 'The lattice types command lists the canonical type for each code prefix, organized
+  by layer. Output formats: Rich table (default) and JSON (--json). The lattice fact
+  add command auto-populates the type field from the registry based on the code prefix
+  when the user does not supply a type. The lattice validate command warns on type
+  mismatches between a fact code prefix and its canonical type. The registry is stored
+  at .lattice/types.yaml and seeded by lattice init.'
+tags:
+- cli
+- controlled-vocabulary
+- developer
+- type-registry
+status: Draft
+confidence: Confirmed
+version: 1
+refs:
+- DES-10
+- DG-10
+- RISK-03
+superseded_by:
+owner: architecture-team
+review_by:
+created_at: '2026-03-05T20:27:26.941337'
+updated_at: '2026-03-05T20:27:26.941338'

--- a/.lattice/history/changelog.jsonl
+++ b/.lattice/history/changelog.jsonl
@@ -70,3 +70,11 @@
 {"timestamp": "2026-03-05T18:11:02.559796", "action": "update", "code": "AUP-06", "reason": "Fix: removed incorrect claim about FactIndex.build() detecting duplicates; clarified two actual enforcement levels"}
 {"timestamp": "2026-03-05T18:11:06.978458", "action": "update", "code": "RISK-06", "reason": "Fix: marked thresholds as future/not-yet-implemented \u2014 values do not exist in current codebase"}
 {"timestamp": "2026-03-05T18:11:10.841965", "action": "update", "code": "DG-06", "reason": "Fix: clarified Review Expired is a runtime condition, not a FactStatus enum value"}
+{"timestamp": "2026-03-05T20:24:37.682534", "action": "update", "code": "DG-05", "reason": "Audit finding: removed snapshot claim to match actual implementation. Git history provides fact-level snapshots."}
+{"timestamp": "2026-03-05T20:24:50.884097", "action": "update", "code": "RISK-06", "reason": "Audit finding: demoted to Draft \u2014 storage tier thresholds not yet implemented."}
+{"timestamp": "2026-03-05T20:25:23.594754", "action": "create", "code": "DES-09", "reason": "Initial creation"}
+{"timestamp": "2026-03-05T20:25:23.596651", "action": "create", "code": "DG-09", "reason": "Initial creation"}
+{"timestamp": "2026-03-05T20:25:23.598092", "action": "create", "code": "SP-08", "reason": "Initial creation"}
+{"timestamp": "2026-03-05T20:27:26.937829", "action": "create", "code": "DES-10", "reason": "Initial creation"}
+{"timestamp": "2026-03-05T20:27:26.941063", "action": "create", "code": "DG-10", "reason": "Initial creation"}
+{"timestamp": "2026-03-05T20:27:26.943475", "action": "create", "code": "SP-09", "reason": "Initial creation"}

--- a/phase5-implementation-brief.md
+++ b/phase5-implementation-brief.md
@@ -512,7 +512,98 @@ lattice serve --host 0.0.0.0 --port 3100 --writable
 
 ---
 
-## 10. What Phase 5 Does NOT Include
+## 10. Side Tasks (Non-MCP Improvements)
+
+These are standalone improvements to ship alongside or shortly after the MCP server. They don't depend on MCP but improve governance quality.
+
+### 10.1 Tag Registry (`lattice tags`)
+
+**Facts**: DES-09, DG-09, SP-08
+
+A centralized tag registry at `.lattice/tags.yaml` that lists all tags in use across the lattice with usage counts and vocabulary category assignments (domain, concern, lifecycle, stakeholder, risk, or free).
+
+**New files**:
+```
+src/lattice_lens/cli/tags_command.py    # NEW: lattice tags
+src/lattice_lens/services/tag_service.py # NEW: tag aggregation + registry generation
+tests/test_tag_service.py               # NEW
+```
+
+**CLI**:
+```bash
+lattice tags                  # Rich table: tag, count, category
+lattice tags --json           # JSON output
+lattice tags --rebuild        # Regenerate .lattice/tags.yaml from current facts
+```
+
+**Validation integration**: `lattice validate` warns when a free tag appears in 3+ facts, suggesting review for inclusion in the controlled vocabulary (per DG-07).
+
+**Key rules**:
+- Tags are case-insensitive (already enforced by DG-02 normalization)
+- No duplicates in the registry
+- Registry is generated, not hand-edited
+- File is committed to git for team visibility
+
+### 10.2 Type Registry (`lattice types`)
+
+**Facts**: DES-10, DG-10, SP-09 — **Mitigates**: RISK-03
+
+A canonical type mapping at `.lattice/types.yaml` that assigns exactly one type string per code prefix. Addresses the RISK-03 finding that free-text type fields cause silent mismatches in role template queries.
+
+**Current inconsistencies found by audit**:
+| Prefix | Divergent Types | Canonical |
+|--------|----------------|-----------|
+| API | API Contract, API Specification | API Specification |
+| MC | Model Card Entry, Monitoring Check | Model Card Entry |
+| RISK | Risk Assessment Finding, Risk Register Entry | Risk Register Entry |
+| RUN | Runbook Entry, Runbook Procedure | Runbook Procedure |
+| SP | Standard Procedure, System Prompt Rule | System Prompt Rule |
+
+**New files**:
+```
+src/lattice_lens/cli/types_command.py    # NEW: lattice types
+src/lattice_lens/services/type_service.py # NEW: type registry + validation
+tests/test_type_service.py               # NEW
+```
+
+**CLI**:
+```bash
+lattice types                 # Rich table: prefix, layer, canonical type
+lattice types --json          # JSON output
+lattice types --audit         # Show facts with non-canonical types
+```
+
+**Behaviors**:
+- `lattice init` seeds `.lattice/types.yaml` with canonical mappings for all 14 prefixes
+- `lattice fact add` auto-populates the type field from the registry when the user doesn't supply one
+- `lattice validate` warns when a fact's type doesn't match its prefix's canonical type
+- `lattice extract --prompt` includes the canonical type mapping so the LLM uses correct types
+
+**Canonical type map** (seeded by `lattice init`):
+```yaml
+# .lattice/types.yaml
+WHY:
+  ADR: Architecture Decision Record
+  PRD: Product Requirement
+  ETH: Ethical Finding
+  DES: Design Proposal Decision
+GUARDRAILS:
+  MC: Model Card Entry
+  AUP: Acceptable Use Policy Rule
+  RISK: Risk Register Entry
+  DG: Data Governance Rule
+  COMP: Compliance Rule
+HOW:
+  SP: System Prompt Rule
+  API: API Specification
+  RUN: Runbook Procedure
+  ML: MLOps Rule
+  MON: Monitoring Rule
+```
+
+---
+
+## 11. What Phase 5 Does NOT Include
 
 - **Authentication** — Phase 5 MCP server is unauthenticated. Auth comes with Phase 7 (Enterprise).
 - **WebSocket push notifications** — polling via repeated tool calls. Push comes with Enterprise.


### PR DESCRIPTION
## Summary
- **DG-05** updated to match implementation: changelog records action/code/timestamp/reason (not snapshots — git history serves that role)
- **RISK-06** demoted to Draft until storage tier thresholds are implemented
- 3 new Draft facts for **tag registry** (DES-09, DG-09, SP-08): centralized `.lattice/tags.yaml` with usage counts, `lattice tags` command, validate warns at 3+ free tag uses
- 3 new Draft facts for **type registry** (DES-10, DG-10, SP-09): canonical `.lattice/types.yaml` mapping each prefix to one type string, mitigates RISK-03
- **Phase 5 brief** updated with Side Tasks section (§10) covering both registries with file layout, CLI specs, and integration points

## Test plan
- [x] `lattice validate` passes after all changes
- [x] DG-05 v2 reflects updated text (no snapshot claim)
- [x] RISK-06 v3 status is Draft
- [x] All 6 new facts (DES-09, DES-10, DG-09, DG-10, SP-08, SP-09) created as Draft
- [x] Changelog entries written for all mutations

🤖 Generated with [Claude Code](https://claude.com/claude-code)