### PR TITLE
Add LLM-powered reconciliation with prompt and API modes

### DIFF
--- a/.claude/hooks/compliance-check.sh
+++ b/.claude/hooks/compliance-check.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 # Stop hook: fires once when Claude finishes responding.
-# Audits source file changes against lattice governance rules.
-# Always reports findings to the user. Blocks (exit 2) on NEW source changes.
+# Runs lattice reconcile --llm-prompt to produce a structured compliance audit
+# with pre-analyzed findings, full fact context, and assessment instructions.
+# Blocks (exit 2) on NEW source changes to force Claude to report.
 #
 # Anti-loop: a stamp file records the fingerprint of already-audited changes.
 # If the current changes match the stamp, we skip blocking to avoid an
-# infinite re-prompt cycle (Stop fires → Claude responds → Stop fires again).
+# infinite re-prompt cycle (Stop fires -> Claude responds -> Stop fires again).
 
 INPUT=$(cat)
 
@@ -53,13 +54,17 @@ if [ "$TOTAL_CODE" -gt 0 ]; then
   git diff --name-only -- src/ 2>/dev/null
   git ls-files --others --exclude-standard -- src/ 2>/dev/null
   echo ""
+
+  # Run lattice reconcile --llm-prompt for structured analysis
+  echo "## Reconciliation Analysis"
+  echo ""
+  lattice reconcile --llm-prompt --path "$PROJECT_DIR/src" 2>/dev/null
+  echo ""
+
   echo "## Instructions"
   echo ""
-  echo "You MUST audit each changed file against the lattice governance rules and report"
-  echo "your findings to the user. For each file:"
-  echo ""
-  echo "1. Identify which governance rules (AUP, DG, RISK, etc.) are relevant"
-  echo "2. Confirm compliance OR identify violations"
+  echo "Review the reconciliation findings above against the modified files."
+  echo "For each finding, confirm compliance or identify violations."
   echo ""
   echo "## Remediation"
   echo ""
@@ -74,12 +79,12 @@ if [ "$TOTAL_CODE" -gt 0 ]; then
   echo "or obsolete procedure), you MUST NOT create, update, or deprecate facts on"
   echo "your own. Instead, present the developer with your recommendation and options:"
   echo ""
-  echo "  1. **Create a new fact** — suggest the code, layer, type, and summary."
+  echo "  1. **Create a new fact** -- suggest the code, layer, type, and summary."
   echo "     Example: 'I recommend creating DG-12 (Data Governance) to cover X.'"
-  echo "  2. **Update an existing fact** — identify which fact and what should change."
+  echo "  2. **Update an existing fact** -- identify which fact and what should change."
   echo "     Example: 'RISK-03 should be updated to include mitigation for Y.'"
-  echo "  3. **Deprecate an existing fact** — explain why it is no longer relevant."
-  echo "     Example: 'ADR-05 is superseded by the new approach — recommend deprecation.'"
+  echo "  3. **Deprecate an existing fact** -- explain why it is no longer relevant."
+  echo "     Example: 'ADR-05 is superseded by the new approach -- recommend deprecation.'"
   echo ""
   echo "Always wait for the developer to approve, modify, or reject your recommendation"
   echo "before making any changes to lattice facts."
@@ -87,9 +92,9 @@ if [ "$TOTAL_CODE" -gt 0 ]; then
   echo "## Reporting"
   echo ""
   echo "After the audit, report your findings to the user in a brief summary like:"
-  echo "  'Governance audit: 4 files reviewed — all compliant with DG-10, RISK-03.'"
-  echo "  'Governance audit: violation in X — fixed code to comply with RISK-03.'"
-  echo "  'Governance audit: gap found — recommending new fact DG-12 (awaiting approval).'"
+  echo "  'Governance audit: 4 files reviewed -- all compliant with DG-10, RISK-03.'"
+  echo "  'Governance audit: violation in X -- fixed code to comply with RISK-03.'"
+  echo "  'Governance audit: gap found -- recommending new fact DG-12 (awaiting approval).'"
 
   if [ "$TOTAL_FACTS" -gt 0 ]; then
     echo ""
@@ -100,20 +105,20 @@ if [ "$TOTAL_CODE" -gt 0 ]; then
   echo "$FINGERPRINT" > "$STAMP_FILE"
 
   if [ "$ALREADY_AUDITED" = true ]; then
-    # Same changes already audited — don't block, just inform
+    # Same changes already audited -- don't block, just inform
     echo ""
     echo "(These changes were already audited in a prior turn. Reporting only.)"
     exit 0
   else
-    # New source changes — block to force Claude to report the audit
+    # New source changes -- block to force Claude to report the audit
     exit 2
   fi
 fi
 
-# No source changes — clean up any stale stamp and report
+# No source changes -- clean up any stale stamp and report
 rm -f "$STAMP_FILE" 2>/dev/null
 echo "# GOVERNANCE AUDIT: CLEAN"
 echo ""
 echo "No source files were modified. No compliance audit needed."
-echo "Briefly inform the user: 'No source changes — governance audit not required.'"
+echo "Briefly inform the user: 'No source changes -- governance audit not required.'"
 exit 0

--- a/README.md
+++ b/README.md
@@ -396,12 +396,52 @@ pip install -e .
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/audit-governance.sh",
+            "timeout": 30
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/compliance-check.sh",
+            "timeout": 30
+          }
+        ]
+      }
     ]
   }
 }
 ```
 
-That's it. Every prompt you submit in Claude Code will now be preceded by the project's governance briefing.
+**Step 3:** Copy the hook scripts into your project:
+
+```bash
+mkdir -p .claude/hooks
+cp .claude/hooks/audit-governance.sh .claude/hooks/
+cp .claude/hooks/compliance-check.sh .claude/hooks/
+```
+
+The three hooks work together as a governance pipeline:
+
+| Hook | Trigger | Purpose |
+|------|---------|---------|
+| `UserPromptSubmit` | Every prompt | Injects governance rules and knowledge context before Claude responds |
+| `PostToolUse` | After `Edit` or `Write` | Runs `lattice validate` after file changes — blocks on validation failure |
+| `Stop` | When Claude finishes responding | Audits modified source files against governance rules — blocks on new changes to force a compliance report |
+
+The `PostToolUse` hook catches lattice integrity issues immediately after edits. The `Stop` hook performs a broader compliance audit once Claude is done, checking all modified `src/` files against governance rules. It uses a stamp file (`.claude/.audit-stamp`) to avoid infinite re-prompt loops — if the same changes have already been audited, it reports findings without blocking.
 
 #### What the agent sees
 

--- a/src/lattice_lens/cli/reconcile_command.py
+++ b/src/lattice_lens/cli/reconcile_command.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
 from typing import Optional
 
@@ -11,9 +12,15 @@ from rich.console import Console
 from rich.table import Table
 
 from lattice_lens.cli.helpers import require_lattice
-from lattice_lens.services.reconcile_service import reconcile, ReconciliationReport
+from lattice_lens.config import Settings
+from lattice_lens.services.reconcile_service import (
+    ReconciliationReport,
+    reconcile,
+    render_reconciliation_prompt,
+)
 
 console = Console()
+err_console = Console(stderr=True)
 
 
 def reconcile_cmd(
@@ -27,7 +34,20 @@ def reconcile_cmd(
         None, "--exclude", help="Glob patterns to exclude."
     ),
     llm: bool = typer.Option(
-        False, "--llm", help="Enable LLM-assisted analysis (not yet implemented)."
+        False, "--llm", help="Enable LLM-assisted analysis via Anthropic API."
+    ),
+    llm_prompt: bool = typer.Option(
+        False,
+        "--llm-prompt",
+        help="Print reconciliation prompt to stdout for agent integration.",
+    ),
+    model: str = typer.Option(
+        "claude-sonnet-4-20250514", "--model", help="Model for LLM analysis."
+    ),
+    api_key: Optional[str] = typer.Option(
+        None,
+        "--api-key",
+        help="Anthropic API key (default: $LATTICE_ANTHROPIC_API_KEY).",
     ),
     json_output: bool = typer.Option(
         False, "--json", help="Output report as JSON."
@@ -37,11 +57,45 @@ def reconcile_cmd(
     ),
 ):
     """Reconcile governance facts against the codebase."""
+    # Mutual exclusion check
+    if llm and llm_prompt:
+        err_console.print(
+            "[red]Error:[/red] --llm and --llm-prompt are mutually exclusive."
+        )
+        raise typer.Exit(1)
+
     store = require_lattice()
 
     # Default scan path: parent of .lattice/ (project root)
     codebase_root = path or store.root.parent
 
+    # ── Prompt mode: run rule-based, render prompt, exit ──
+    if llm_prompt:
+        report = reconcile(
+            store,
+            codebase_root,
+            include_patterns=include,
+            exclude_patterns=exclude,
+        )
+        active_facts = store.list_facts(status=["Active"])
+        prompt_text = render_reconciliation_prompt(report, active_facts)
+        sys.stdout.buffer.write(prompt_text.encode("utf-8"))
+        sys.stdout.buffer.write(b"\n")
+        return
+
+    # ── Direct LLM mode: resolve API key ──
+    if llm:
+        resolved_key = api_key or Settings().anthropic_api_key
+        if not resolved_key:
+            err_console.print(
+                "[red]Error:[/red] No API key provided. "
+                "Set LATTICE_ANTHROPIC_API_KEY or use --api-key."
+            )
+            raise typer.Exit(1)
+    else:
+        resolved_key = None
+
+    # ── Run reconciliation ──
     try:
         report = reconcile(
             store,
@@ -49,9 +103,11 @@ def reconcile_cmd(
             include_patterns=include,
             exclude_patterns=exclude,
             use_llm=llm,
+            api_key=resolved_key,
+            model=model,
         )
-    except NotImplementedError as e:
-        console.print(f"[red]Error:[/red] {e}")
+    except ValueError as e:
+        err_console.print(f"[red]Error:[/red] {e}")
         raise typer.Exit(1)
 
     if json_output:
@@ -98,6 +154,8 @@ def _print_rich(report: ReconciliationReport, verbose: bool):
             console.print(f"  {f.code} \u2014 {f.description}")
             if f.file:
                 console.print(f"           {f.file}:{f.line}")
+            if verbose and f.llm_reasoning:
+                console.print(f"           [dim]LLM: {f.llm_reasoning}[/dim]")
 
     if report.violated:
         console.print("\n[red]\u2717 Violated:[/red]")
@@ -105,6 +163,8 @@ def _print_rich(report: ReconciliationReport, verbose: bool):
             console.print(f"  {f.code} \u2014 {f.description}")
             if f.file:
                 console.print(f"           {f.file}:{f.line}")
+            if verbose and f.llm_reasoning:
+                console.print(f"           [dim]LLM: {f.llm_reasoning}[/dim]")
 
     if report.untracked:
         console.print("\n[blue]! Untracked Patterns:[/blue]")
@@ -112,6 +172,8 @@ def _print_rich(report: ReconciliationReport, verbose: bool):
             console.print(f"  {f.description}")
             if f.file:
                 console.print(f"             {f.file}:{f.line}")
+            if verbose and f.llm_reasoning:
+                console.print(f"             [dim]LLM: {f.llm_reasoning}[/dim]")
 
     if verbose:
         if report.confirmed:
@@ -120,15 +182,19 @@ def _print_rich(report: ReconciliationReport, verbose: bool):
                 console.print(f"  {f.code} \u2014 {f.description}")
                 if f.file:
                     console.print(f"           {f.file}:{f.line}")
+                if f.llm_reasoning:
+                    console.print(f"           [dim]LLM: {f.llm_reasoning}[/dim]")
 
         if report.orphaned:
             console.print("\n[dim]? Orphaned Facts:[/dim]")
             for f in report.orphaned:
                 console.print(f"  {f.code} \u2014 {f.description}")
+                if f.llm_reasoning:
+                    console.print(f"           [dim]LLM: {f.llm_reasoning}[/dim]")
 
 
 def _finding_dict(f) -> dict:
-    return {
+    d = {
         "category": f.category,
         "code": f.code,
         "description": f.description,
@@ -137,3 +203,6 @@ def _finding_dict(f) -> dict:
         "confidence": f.confidence,
         "evidence": f.evidence,
     }
+    if f.llm_reasoning:
+        d["llm_reasoning"] = f.llm_reasoning
+    return d

--- a/src/lattice_lens/services/reconcile_service.py
+++ b/src/lattice_lens/services/reconcile_service.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -11,6 +13,38 @@ from lattice_lens.services.code_scanner import (
     scan_for_fact_references,
 )
 from lattice_lens.store.protocol import LatticeStore
+
+
+RECONCILIATION_SYSTEM_PROMPT = """You are a governance reconciliation engine for LatticeLens.
+
+You analyze relationships between governance facts (documented architectural decisions, \
+rules, and policies) and source code to assess whether governance is accurately reflected \
+in the implementation.
+
+For each finding below, you will see:
+- The finding category assigned by rule-based matching (confirmed, orphaned, untracked, stale, violated)
+- The governance fact text (if applicable)
+- Code evidence (file path, line number, code snippet)
+
+Your job:
+1. VALIDATE confirmed findings: Does the code genuinely implement/reference this fact, \
+or is the regex match a false positive?
+2. RESCUE orphaned findings: Is this fact semantically implemented in code even without \
+an explicit code reference?
+3. DETECT violations: Does any code evidence contradict or violate a governance fact?
+4. ASSESS staleness: Has the code evolved beyond what the fact describes?
+5. EVALUATE untracked patterns: Are these genuinely undocumented architectural decisions?
+
+Respond ONLY with a valid JSON array. Each object must have:
+- original_category: string (the category from rule-based analysis)
+- revised_category: string ("confirmed", "stale", "violated", "untracked", "orphaned")
+- code: string or null (fact code if applicable)
+- confidence: float (0.0-1.0, your confidence in the revised category)
+- reasoning: string (1-2 sentence explanation of your assessment)
+- file: string or null
+- line: integer or null
+
+Do not include any preamble, explanation, or markdown formatting. Only valid JSON."""
 
 
 @dataclass
@@ -24,6 +58,7 @@ class Finding:
     line: int | None  # Line number in source
     confidence: float  # 0.0-1.0 confidence in the finding
     evidence: str  # Code snippet or text supporting the finding
+    llm_reasoning: str | None = None  # LLM's assessment explanation
 
 
 @dataclass
@@ -90,6 +125,244 @@ def _is_pattern_covered(
     return False
 
 
+def render_reconciliation_prompt(
+    report: ReconciliationReport,
+    active_facts: list,
+) -> str:
+    """Render reconciliation findings into a structured prompt for agent integration.
+
+    Generates a complete prompt containing the system instructions, active fact
+    definitions, and rule-based findings that a developer can feed to an AI agent
+    (e.g., Claude Code) for semantic analysis.
+
+    Args:
+        report: Rule-based reconciliation report.
+        active_facts: Active facts from the lattice store.
+
+    Returns:
+        Structured prompt text suitable for agent injection.
+    """
+    sections: list[str] = []
+
+    # Section 1: System instructions
+    sections.append(RECONCILIATION_SYSTEM_PROMPT)
+
+    # Section 2: Active facts
+    sections.append("\n---\n\n## Active Governance Facts\n")
+    if active_facts:
+        for fact in active_facts:
+            tags_str = ", ".join(fact.tags) if fact.tags else "none"
+            refs_str = ", ".join(fact.refs) if fact.refs else "none"
+            sections.append(
+                f"### [{fact.code}] {fact.type} ({fact.layer.value})\n"
+                f"Tags: {tags_str}\n"
+                f"Refs: {refs_str}\n"
+                f"Confidence: {fact.confidence.value}\n\n"
+                f"{fact.fact}\n"
+            )
+    else:
+        sections.append("No active facts in the lattice.\n")
+
+    # Section 3: Findings by category
+    sections.append("\n---\n\n## Rule-Based Findings\n")
+
+    categories = [
+        ("Confirmed", report.confirmed),
+        ("Stale", report.stale),
+        ("Violated", report.violated),
+        ("Untracked", report.untracked),
+        ("Orphaned", report.orphaned),
+    ]
+
+    for label, findings in categories:
+        if not findings:
+            continue
+        sections.append(f"\n### {label} ({len(findings)})\n")
+        for f in findings:
+            loc = f"{f.file}:{f.line}" if f.file else "no file"
+            sections.append(
+                f"- **{f.code or 'N/A'}** ({f.category}, confidence={f.confidence:.2f})\n"
+                f"  Location: {loc}\n"
+                f"  Description: {f.description}\n"
+                f"  Evidence: {f.evidence[:300]}\n"
+            )
+
+    # Section 4: Usage hint
+    sections.append(
+        "\n---\n\n"
+        "Feed this prompt to your AI agent (e.g., Claude Code) for semantic analysis.\n"
+        "The agent should analyze each finding against the governance facts and return\n"
+        "its assessment as a JSON array following the schema above.\n"
+    )
+
+    return "\n".join(sections)
+
+
+def _build_llm_user_message(
+    report: ReconciliationReport,
+    active_facts: list,
+) -> str:
+    """Build the user message for the LLM API call.
+
+    Contains fact definitions and findings without the system prompt
+    (which is passed separately via the system parameter).
+    """
+    sections: list[str] = []
+
+    # Active facts
+    sections.append("## Active Governance Facts\n")
+    for fact in active_facts:
+        tags_str = ", ".join(fact.tags) if fact.tags else "none"
+        refs_str = ", ".join(fact.refs) if fact.refs else "none"
+        sections.append(
+            f"### [{fact.code}] {fact.type} ({fact.layer.value})\n"
+            f"Tags: {tags_str} | Refs: {refs_str} | "
+            f"Confidence: {fact.confidence.value}\n\n"
+            f"{fact.fact}\n"
+        )
+
+    # Findings
+    sections.append("\n## Rule-Based Findings to Analyze\n")
+
+    all_findings: list[Finding] = (
+        report.confirmed
+        + report.stale
+        + report.violated
+        + report.untracked
+        + report.orphaned
+    )
+
+    if not all_findings:
+        sections.append("No findings to analyze.\n")
+    else:
+        for f in all_findings:
+            loc = f"{f.file}:{f.line}" if f.file else "no file"
+            sections.append(
+                f"- category={f.category}, code={f.code or 'N/A'}, "
+                f"confidence={f.confidence:.2f}\n"
+                f"  Location: {loc}\n"
+                f"  Description: {f.description}\n"
+                f"  Evidence: {f.evidence[:300]}\n"
+            )
+
+    return "\n".join(sections)
+
+
+_VALID_CATEGORIES = {"confirmed", "stale", "violated", "untracked", "orphaned"}
+
+
+def llm_reconcile(
+    report: ReconciliationReport,
+    active_facts: list,
+    api_key: str,
+    model: str = "claude-sonnet-4-20250514",
+) -> ReconciliationReport:
+    """Enrich a rule-based reconciliation report with LLM semantic analysis.
+
+    Sends findings and fact definitions to the Anthropic API for deeper
+    analysis. The LLM can reclassify findings, adjust confidence scores,
+    and provide reasoning.
+
+    On invalid JSON from the LLM, falls back to the original report with
+    a warning on stderr.
+
+    Args:
+        report: Rule-based reconciliation report.
+        active_facts: Active facts from the lattice store.
+        api_key: Anthropic API key.
+        model: Model to use for analysis.
+
+    Returns:
+        Enriched ReconciliationReport with LLM assessments.
+    """
+    from anthropic import Anthropic
+
+    user_msg = _build_llm_user_message(report, active_facts)
+
+    client = Anthropic(api_key=api_key)
+    response = client.messages.create(
+        model=model,
+        max_tokens=4096,
+        system=RECONCILIATION_SYSTEM_PROMPT,
+        messages=[{"role": "user", "content": user_msg}],
+    )
+
+    response_text = response.content[0].text.strip()
+    # Strip markdown code fences if present
+    if response_text.startswith("```"):
+        response_text = response_text.split("\n", 1)[1]
+    if response_text.endswith("```"):
+        response_text = response_text.rsplit("\n", 1)[0]
+
+    try:
+        llm_findings = json.loads(response_text)
+    except json.JSONDecodeError as e:
+        print(
+            f"Warning: LLM returned invalid JSON, falling back to rule-based "
+            f"report: {e}",
+            file=sys.stderr,
+        )
+        return report
+
+    if not isinstance(llm_findings, list):
+        print(
+            "Warning: LLM response is not a JSON array, falling back to "
+            "rule-based report.",
+            file=sys.stderr,
+        )
+        return report
+
+    # Build enriched report from LLM results
+    enriched = ReconciliationReport()
+
+    for item in llm_findings:
+        try:
+            revised_cat = item.get("revised_category", item.get("original_category", "orphaned"))
+            if revised_cat not in _VALID_CATEGORIES:
+                continue
+
+            finding = Finding(
+                category=revised_cat,
+                code=item.get("code"),
+                description=item.get("reasoning", "LLM assessment"),
+                file=item.get("file"),
+                line=item.get("line"),
+                confidence=float(item.get("confidence", 0.5)),
+                evidence="",
+                llm_reasoning=item.get("reasoning"),
+            )
+
+            # Preserve original evidence from the rule-based finding
+            if finding.code:
+                original = _find_original(report, finding.code)
+                if original:
+                    finding.evidence = original.evidence
+
+            category_list = getattr(enriched, revised_cat, None)
+            if category_list is not None:
+                category_list.append(finding)
+
+        except (TypeError, ValueError, KeyError) as e:
+            print(
+                f"Warning: skipping invalid LLM finding: {e}",
+                file=sys.stderr,
+            )
+
+    return enriched
+
+
+def _find_original(report: ReconciliationReport, code: str) -> Finding | None:
+    """Find the original rule-based finding by fact code."""
+    for category_list in [
+        report.confirmed, report.stale, report.violated,
+        report.untracked, report.orphaned,
+    ]:
+        for f in category_list:
+            if f.code == code:
+                return f
+    return None
+
+
 def reconcile(
     store: LatticeStore,
     codebase_root: Path,
@@ -97,23 +370,30 @@ def reconcile(
     include_patterns: list[str] | None = None,
     exclude_patterns: list[str] | None = None,
     use_llm: bool = False,
+    api_key: str | None = None,
+    model: str = "claude-sonnet-4-20250514",
 ) -> ReconciliationReport:
     """Run bidirectional reconciliation.
 
     Facts-to-Code: For each active fact, check if the codebase references it.
     Code-to-Facts: Scan for architectural patterns with no corresponding fact.
 
+    When use_llm is True, rule-based findings are enriched by sending them to
+    the Anthropic API for semantic analysis.
+
     Args:
         store: LatticeStore instance.
         codebase_root: Directory to scan.
         include_patterns: Glob patterns to include (default: **/*.py).
         exclude_patterns: Glob patterns to exclude.
-        use_llm: Enable LLM-assisted analysis (not yet implemented).
+        use_llm: Enable LLM-assisted analysis via Anthropic API.
+        api_key: Anthropic API key (required when use_llm=True).
+        model: Model to use for LLM analysis.
     """
-    if use_llm:
-        raise NotImplementedError(
-            "LLM-assisted reconciliation is planned but not yet implemented. "
-            "Remove --llm flag to use rule-based matching."
+    if use_llm and not api_key:
+        raise ValueError(
+            "API key required for LLM-assisted reconciliation. "
+            "Set LATTICE_ANTHROPIC_API_KEY or use --api-key."
         )
 
     report = ReconciliationReport()
@@ -184,5 +464,9 @@ def reconcile(
                 )
             )
             seen_categories.add(pattern.category)
+
+    # ── LLM enrichment (Phase 2) ──
+    if use_llm:
+        report = llm_reconcile(report, active_facts, api_key, model)
 
     return report

--- a/tests/test_reconcile_cli.py
+++ b/tests/test_reconcile_cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 from typer.testing import CliRunner
 
@@ -41,6 +42,15 @@ def _add_fact(lattice_root: Path, fact):
     store.create(fact)
 
 
+def _mock_api_response(json_text: str):
+    """Create a mock Anthropic client that returns json_text as the response."""
+    mock_response = MagicMock()
+    mock_response.content = [MagicMock(text=json_text)]
+    mock_client = MagicMock()
+    mock_client.messages.create.return_value = mock_response
+    return mock_client
+
+
 class TestReconcileCli:
     def test_reconcile_runs(self, tmp_path, monkeypatch):
         lattice_root, project_root = _setup_project(tmp_path)
@@ -75,15 +85,123 @@ class TestReconcileCli:
         assert result.exit_code == 0
         assert "Confirmed" in result.output or "Orphaned" in result.output
 
-    def test_reconcile_llm_flag_errors(self, tmp_path, monkeypatch):
-        lattice_root, _ = _setup_project(tmp_path)
-        monkeypatch.chdir(tmp_path)
-        result = runner.invoke(app, ["reconcile", "--llm"])
-        assert result.exit_code == 1
-        assert "not yet implemented" in result.output.lower()
-
     def test_reconcile_no_lattice(self, tmp_path, monkeypatch):
         """Running reconcile without .lattice/ should error."""
         monkeypatch.chdir(tmp_path)
         result = runner.invoke(app, ["reconcile"])
         assert result.exit_code == 1
+
+
+class TestReconcileLlmCli:
+    def test_reconcile_llm_requires_api_key(self, tmp_path, monkeypatch):
+        """--llm without API key should error."""
+        lattice_root, _ = _setup_project(tmp_path)
+        _add_fact(lattice_root, make_fact(code="ADR-01"))
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("LATTICE_ANTHROPIC_API_KEY", raising=False)
+        result = runner.invoke(app, ["reconcile", "--llm"])
+        assert result.exit_code == 1
+        assert "api key" in result.output.lower()
+
+    def test_reconcile_llm_and_prompt_exclusive(self, tmp_path, monkeypatch):
+        """--llm and --llm-prompt together should error."""
+        lattice_root, _ = _setup_project(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        result = runner.invoke(app, ["reconcile", "--llm", "--llm-prompt"])
+        assert result.exit_code == 1
+        assert "mutually exclusive" in result.output.lower()
+
+    def test_reconcile_llm_prompt_outputs_text(self, tmp_path, monkeypatch):
+        """--llm-prompt should print structured prompt to stdout."""
+        lattice_root, _ = _setup_project(tmp_path)
+        _add_fact(lattice_root, make_fact(code="ADR-01"))
+        monkeypatch.chdir(tmp_path)
+        result = runner.invoke(
+            app, ["reconcile", "--llm-prompt", "--path", str(tmp_path / "src")]
+        )
+        assert result.exit_code == 0
+        assert "reconciliation" in result.output.lower()
+        assert "ADR-01" in result.output
+
+    def test_reconcile_llm_prompt_contains_fact_text(self, tmp_path, monkeypatch):
+        """--llm-prompt output should include full fact text."""
+        lattice_root, _ = _setup_project(tmp_path)
+        _add_fact(lattice_root, make_fact(
+            code="RISK-01",
+            layer="GUARDRAILS",
+            type="Risk Register Entry",
+            fact="Prompt injection via user-uploaded documents is high severity.",
+            tags=["security", "prompt-injection"],
+        ))
+        monkeypatch.chdir(tmp_path)
+        result = runner.invoke(
+            app, ["reconcile", "--llm-prompt", "--path", str(tmp_path / "src")]
+        )
+        assert result.exit_code == 0
+        assert "Prompt injection" in result.output
+        assert "RISK-01" in result.output
+
+    def test_reconcile_llm_with_mock_api(self, tmp_path, monkeypatch):
+        """--llm with mocked API should produce enriched output."""
+        lattice_root, _ = _setup_project(tmp_path)
+        _add_fact(lattice_root, make_fact(code="ADR-01"))
+        monkeypatch.chdir(tmp_path)
+
+        llm_response = json.dumps([
+            {
+                "original_category": "confirmed",
+                "revised_category": "confirmed",
+                "code": "ADR-01",
+                "confidence": 0.95,
+                "reasoning": "Explicit code reference found.",
+                "file": "main.py",
+                "line": 1,
+            }
+        ])
+
+        mock_client = _mock_api_response(llm_response)
+        with patch("anthropic.Anthropic", return_value=mock_client):
+            result = runner.invoke(
+                app,
+                [
+                    "reconcile", "--llm",
+                    "--api-key", "test-key",
+                    "--path", str(tmp_path / "src"),
+                ],
+            )
+        assert result.exit_code == 0
+        assert "Reconciliation Report" in result.output
+
+    def test_reconcile_llm_json_with_reasoning(self, tmp_path, monkeypatch):
+        """--llm --json should include llm_reasoning in output."""
+        lattice_root, _ = _setup_project(tmp_path)
+        _add_fact(lattice_root, make_fact(code="ADR-01"))
+        monkeypatch.chdir(tmp_path)
+
+        llm_response = json.dumps([
+            {
+                "original_category": "confirmed",
+                "revised_category": "confirmed",
+                "code": "ADR-01",
+                "confidence": 0.95,
+                "reasoning": "Explicit reference in comment.",
+                "file": "main.py",
+                "line": 1,
+            }
+        ])
+
+        mock_client = _mock_api_response(llm_response)
+        with patch("anthropic.Anthropic", return_value=mock_client):
+            result = runner.invoke(
+                app,
+                [
+                    "reconcile", "--llm", "--json",
+                    "--api-key", "test-key",
+                    "--path", str(tmp_path / "src"),
+                ],
+            )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        confirmed = data["findings"]["confirmed"]
+        assert len(confirmed) >= 1
+        assert "llm_reasoning" in confirmed[0]

--- a/tests/test_reconcile_service.py
+++ b/tests/test_reconcile_service.py
@@ -2,13 +2,21 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from tests.conftest import make_fact
 from lattice_lens.models import FactStatus
-from lattice_lens.services.reconcile_service import reconcile, ReconciliationReport
+from lattice_lens.services.reconcile_service import (
+    Finding,
+    ReconciliationReport,
+    RECONCILIATION_SYSTEM_PROMPT,
+    reconcile,
+    render_reconciliation_prompt,
+)
 
 
 def _write_file(root: Path, relpath: str, content: str) -> Path:
@@ -16,6 +24,15 @@ def _write_file(root: Path, relpath: str, content: str) -> Path:
     p.parent.mkdir(parents=True, exist_ok=True)
     p.write_text(content)
     return p
+
+
+def _mock_api_response(json_text: str):
+    """Create a mock Anthropic client that returns json_text as the response."""
+    mock_response = MagicMock()
+    mock_response.content = [MagicMock(text=json_text)]
+    mock_client = MagicMock()
+    mock_client.messages.create.return_value = mock_response
+    return mock_client
 
 
 class TestReconcileFactsToCode:
@@ -131,8 +148,6 @@ class TestReconciliationReport:
 
     def test_coverage_calculation(self):
         """coverage_pct = confirmed / total_checked * 100."""
-        from lattice_lens.services.reconcile_service import Finding
-
         report = ReconciliationReport()
         report.confirmed = [
             Finding("confirmed", "A-1", "ok", "f.py", 1, 0.8, "x")
@@ -168,9 +183,214 @@ class TestReconciliationReport:
         # ADR-01 reference is in excluded vendor dir
         assert len(report.confirmed) == 0
 
-    def test_use_llm_raises(self, yaml_store, tmp_path):
-        """use_llm=True should raise NotImplementedError."""
+
+class TestLlmReconcile:
+    def test_use_llm_requires_api_key(self, yaml_store, tmp_path):
+        """use_llm=True without api_key should raise ValueError."""
         code_root = tmp_path / "src"
         code_root.mkdir()
-        with pytest.raises(NotImplementedError):
+        with pytest.raises(ValueError, match="API key"):
             reconcile(yaml_store, code_root, use_llm=True)
+
+    def test_llm_reconcile_enriches_findings(self, yaml_store, tmp_path):
+        """LLM call should update finding categories and confidence."""
+        fact = make_fact(code="ADR-01", status=FactStatus.ACTIVE)
+        yaml_store.create(fact)
+
+        code_root = tmp_path / "src"
+        code_root.mkdir()
+        _write_file(code_root, "main.py", "# uses Typer framework\nimport typer\n")
+
+        llm_response = json.dumps([
+            {
+                "original_category": "orphaned",
+                "revised_category": "confirmed",
+                "code": "ADR-01",
+                "confidence": 0.9,
+                "reasoning": "The code imports typer which implements this ADR.",
+                "file": "main.py",
+                "line": 2,
+            }
+        ])
+
+        mock_client = _mock_api_response(llm_response)
+        with patch("anthropic.Anthropic", return_value=mock_client):
+            report = reconcile(
+                yaml_store, code_root,
+                use_llm=True, api_key="test-key",
+            )
+
+        assert len(report.confirmed) >= 1
+        confirmed_with_reasoning = [f for f in report.confirmed if f.llm_reasoning]
+        assert len(confirmed_with_reasoning) >= 1
+        assert "typer" in confirmed_with_reasoning[0].llm_reasoning.lower()
+
+    def test_llm_reconcile_fallback_on_bad_json(self, yaml_store, tmp_path):
+        """If LLM returns invalid JSON, fall back to rule-based report."""
+        fact = make_fact(code="ADR-01", status=FactStatus.ACTIVE)
+        yaml_store.create(fact)
+
+        code_root = tmp_path / "src"
+        code_root.mkdir()
+        _write_file(code_root, "main.py", "# ADR-01\n")
+
+        mock_client = _mock_api_response("not valid json at all")
+        with patch("anthropic.Anthropic", return_value=mock_client):
+            report = reconcile(
+                yaml_store, code_root,
+                use_llm=True, api_key="test-key",
+            )
+
+        # Should fall back to the rule-based result
+        assert len(report.confirmed) == 1
+        assert report.confirmed[0].code == "ADR-01"
+
+    def test_llm_reconcile_with_code_fences(self, yaml_store, tmp_path):
+        """LLM response wrapped in code fences should be parsed correctly."""
+        fact = make_fact(code="ADR-01", status=FactStatus.ACTIVE)
+        yaml_store.create(fact)
+
+        code_root = tmp_path / "src"
+        code_root.mkdir()
+        _write_file(code_root, "main.py", "# ADR-01\n")
+
+        inner_json = json.dumps([
+            {
+                "original_category": "confirmed",
+                "revised_category": "confirmed",
+                "code": "ADR-01",
+                "confidence": 0.95,
+                "reasoning": "Explicit reference found.",
+                "file": "main.py",
+                "line": 1,
+            }
+        ])
+        fenced = f"```json\n{inner_json}\n```"
+
+        mock_client = _mock_api_response(fenced)
+        with patch("anthropic.Anthropic", return_value=mock_client):
+            report = reconcile(
+                yaml_store, code_root,
+                use_llm=True, api_key="test-key",
+            )
+
+        assert len(report.confirmed) == 1
+        assert report.confirmed[0].confidence == 0.95
+
+    def test_llm_reconcile_non_array_fallback(self, yaml_store, tmp_path):
+        """If LLM returns valid JSON but not an array, fall back."""
+        fact = make_fact(code="ADR-01", status=FactStatus.ACTIVE)
+        yaml_store.create(fact)
+
+        code_root = tmp_path / "src"
+        code_root.mkdir()
+        _write_file(code_root, "main.py", "# ADR-01\n")
+
+        mock_client = _mock_api_response('{"error": "unexpected format"}')
+        with patch("anthropic.Anthropic", return_value=mock_client):
+            report = reconcile(
+                yaml_store, code_root,
+                use_llm=True, api_key="test-key",
+            )
+
+        # Should fall back to the rule-based result
+        assert len(report.confirmed) == 1
+
+
+class TestRenderReconciliationPrompt:
+    def test_prompt_contains_system_instructions(self, yaml_store, tmp_path):
+        """Prompt should include the system instructions."""
+        fact = make_fact(code="ADR-01", status=FactStatus.ACTIVE)
+        yaml_store.create(fact)
+
+        code_root = tmp_path / "src"
+        code_root.mkdir()
+        _write_file(code_root, "main.py", "# ADR-01\n")
+
+        report = reconcile(yaml_store, code_root)
+        active_facts = yaml_store.list_facts(status=["Active"])
+        prompt = render_reconciliation_prompt(report, active_facts)
+
+        assert "reconciliation" in prompt.lower()
+        assert "VALIDATE" in prompt
+        assert "RESCUE" in prompt
+
+    def test_prompt_contains_findings(self, yaml_store, tmp_path):
+        """Prompt should include fact codes and finding categories."""
+        fact = make_fact(code="ADR-01", status=FactStatus.ACTIVE)
+        yaml_store.create(fact)
+
+        code_root = tmp_path / "src"
+        code_root.mkdir()
+        _write_file(code_root, "main.py", "# ADR-01\n")
+
+        report = reconcile(yaml_store, code_root)
+        active_facts = yaml_store.list_facts(status=["Active"])
+        prompt = render_reconciliation_prompt(report, active_facts)
+
+        assert "ADR-01" in prompt
+        assert "confirmed" in prompt.lower()
+
+    def test_prompt_contains_fact_text(self, yaml_store, tmp_path):
+        """Full fact text should appear in the prompt."""
+        fact = make_fact(
+            code="RISK-01",
+            status=FactStatus.ACTIVE,
+            layer="GUARDRAILS",
+            type="Risk Register Entry",
+            fact="Prompt injection via uploaded docs is a high severity risk.",
+            tags=["security", "prompt-injection"],
+        )
+        yaml_store.create(fact)
+
+        code_root = tmp_path / "src"
+        code_root.mkdir()
+        _write_file(code_root, "main.py", "# no refs\n")
+
+        report = reconcile(yaml_store, code_root)
+        active_facts = yaml_store.list_facts(status=["Active"])
+        prompt = render_reconciliation_prompt(report, active_facts)
+
+        assert "Prompt injection via uploaded docs" in prompt
+        assert "RISK-01" in prompt
+        assert "security" in prompt
+
+    def test_prompt_with_no_facts(self, yaml_store, tmp_path):
+        """Prompt should handle empty lattice gracefully."""
+        code_root = tmp_path / "src"
+        code_root.mkdir()
+        _write_file(code_root, "main.py", "x = 1\n")
+
+        report = reconcile(yaml_store, code_root)
+        active_facts = yaml_store.list_facts(status=["Active"])
+        prompt = render_reconciliation_prompt(report, active_facts)
+
+        assert "No active facts" in prompt
+
+    def test_prompt_contains_usage_hint(self, yaml_store, tmp_path):
+        """Prompt should include usage instructions for the developer."""
+        code_root = tmp_path / "src"
+        code_root.mkdir()
+        _write_file(code_root, "main.py", "x = 1\n")
+
+        report = reconcile(yaml_store, code_root)
+        active_facts = yaml_store.list_facts(status=["Active"])
+        prompt = render_reconciliation_prompt(report, active_facts)
+
+        assert "agent" in prompt.lower()
+        assert "JSON" in prompt
+
+
+class TestFindingLlmReasoning:
+    def test_finding_default_no_reasoning(self):
+        """Finding should default to no LLM reasoning."""
+        f = Finding("confirmed", "ADR-01", "ok", "f.py", 1, 0.8, "evidence")
+        assert f.llm_reasoning is None
+
+    def test_finding_with_reasoning(self):
+        """Finding should accept LLM reasoning."""
+        f = Finding(
+            "confirmed", "ADR-01", "ok", "f.py", 1, 0.8, "evidence",
+            llm_reasoning="This code clearly implements the ADR.",
+        )
+        assert f.llm_reasoning == "This code clearly implements the ADR."


### PR DESCRIPTION
## Summary
- **`--llm-prompt` mode**: Generates a structured prompt containing rule-based findings, full governance fact text, and semantic assessment instructions. Designed for agent integration — no API key needed, works with whatever agent the developer is already using (Claude Code, etc.)
- **`--llm` mode**: Calls the Anthropic API directly for automated semantic analysis. Enriches findings with LLM-assessed categories, confidence scores, and reasoning. Supports `--model` and `--api-key` flags. Ideal for CI pipelines.
- **Stop hook upgrade**: `compliance-check.sh` now uses `--llm-prompt` to give Claude pre-analyzed reconciliation findings instead of a raw file list with generic instructions
- **README**: Documents all three hooks (`UserPromptSubmit`, `PostToolUse`, `Stop`) with setup instructions

## Test plan
- [x] 32 reconcile tests pass (was 17, now 32)
- [x] 340 total tests pass, 1 skipped (API integration test)
- [x] Manual `lattice reconcile --llm-prompt` produces structured output
- [x] Manual `compliance-check.sh` hook test confirms integration
- [x] `--llm` and `--llm-prompt` mutual exclusion verified
- [x] `--llm` without API key produces clear error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)