### PR TITLE
Add lattice check command for CI pipeline gating

### DIFF
--- a/src/lattice_lens/cli/check_command.py
+++ b/src/lattice_lens/cli/check_command.py
@@ -1,0 +1,160 @@
+"""lattice check — CI-friendly integrity gate."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Optional
+
+import typer
+from rich.console import Console
+
+from lattice_lens.cli.helpers import require_lattice
+from lattice_lens.config import load_config
+from lattice_lens.services.check_service import CheckResult, run_check
+
+console = Console()
+err_console = Console(stderr=True)
+
+
+def _print_text(result: CheckResult) -> None:
+    """Rich console output (default)."""
+    if result.errors:
+        console.print(f"\n[red]Errors ({len(result.errors)}):[/red]")
+        for item in result.errors:
+            loc = ""
+            if item.file:
+                loc = f" ({item.file}"
+                if item.line:
+                    loc += f":{item.line}"
+                loc += ")"
+            console.print(f"  [red]\u2717[/red] {item.message}{loc}")
+
+    if result.warnings:
+        console.print(f"\n[yellow]Warnings ({len(result.warnings)}):[/yellow]")
+        for item in result.warnings:
+            loc = ""
+            if item.file:
+                loc = f" ({item.file}"
+                if item.line:
+                    loc += f":{item.line}"
+                loc += ")"
+            console.print(f"  [yellow]\u2022[/yellow] {item.message}{loc}")
+
+    if result.coverage_pct is not None:
+        console.print(f"\nCoverage: {result.coverage_pct:.1f}%")
+
+
+def _print_json(result: CheckResult, passed: bool) -> None:
+    """Machine-readable JSON output."""
+    data = {
+        "passed": passed,
+        "errors": [
+            {"message": i.message, "file": i.file, "line": i.line}
+            for i in result.errors
+        ],
+        "warnings": [
+            {"message": i.message, "file": i.file, "line": i.line}
+            for i in result.warnings
+        ],
+        "coverage_pct": result.coverage_pct,
+    }
+    sys.stdout.write(json.dumps(data, indent=2) + "\n")
+
+
+def _print_github(result: CheckResult) -> None:
+    """GitHub Actions annotation format."""
+    for item in result.errors:
+        parts = ["::error"]
+        attrs = []
+        if item.file:
+            attrs.append(f"file={item.file}")
+        if item.line:
+            attrs.append(f"line={item.line}")
+        if attrs:
+            parts[0] += " " + ",".join(attrs)
+        sys.stdout.write(f"{parts[0]}::{item.message}\n")
+
+    for item in result.warnings:
+        parts = ["::warning"]
+        attrs = []
+        if item.file:
+            attrs.append(f"file={item.file}")
+        if item.line:
+            attrs.append(f"line={item.line}")
+        if attrs:
+            parts[0] += " " + ",".join(attrs)
+        sys.stdout.write(f"{parts[0]}::{item.message}\n")
+
+
+def check(
+    strict: bool = typer.Option(False, "--strict", help="Treat warnings as errors"),
+    stale_is_error: bool = typer.Option(
+        False, "--stale-is-error", help="Treat stale facts as errors"
+    ),
+    reconcile_path: Optional[Path] = typer.Option(
+        None, "--reconcile", help="Run reconciliation against codebase at PATH"
+    ),
+    include: Optional[list[str]] = typer.Option(
+        None, "--include", help="Glob patterns for reconciliation"
+    ),
+    exclude: Optional[list[str]] = typer.Option(
+        None, "--exclude", help="Glob exclusions for reconciliation"
+    ),
+    min_coverage: int = typer.Option(
+        0, "--min-coverage", help="Minimum coverage %% (requires --reconcile)"
+    ),
+    output_format: str = typer.Option(
+        "text", "--format", help="Output format: text, json, github"
+    ),
+):
+    """CI gate: run all integrity checks and exit 0 (pass) or 1 (fail)."""
+    store = require_lattice()
+
+    # Load config-file defaults, CLI flags override
+    config = load_config(store.root)
+    check_config = config.get("check", {})
+
+    effective_strict = strict or check_config.get("strict", False)
+    effective_stale = stale_is_error or check_config.get("stale_is_error", False)
+    effective_min_cov = min_coverage or check_config.get("min_coverage", 0)
+
+    if reconcile_path is None:
+        cfg_path = check_config.get("reconcile_path")
+        if cfg_path:
+            reconcile_path = Path(cfg_path)
+
+    if min_coverage and not reconcile_path:
+        err_console.print(
+            "[red]Error:[/red] --min-coverage requires --reconcile"
+        )
+        raise typer.Exit(1)
+
+    result = run_check(
+        store,
+        stale_is_error=effective_stale,
+        reconcile_path=reconcile_path,
+        include_patterns=include,
+        exclude_patterns=exclude,
+        min_coverage=effective_min_cov,
+    )
+
+    passed = not result.failed(strict=effective_strict)
+
+    # Render output
+    if output_format == "json":
+        _print_json(result, passed)
+    elif output_format == "github":
+        _print_github(result)
+    else:
+        _print_text(result)
+        if passed:
+            console.print("\n[green]Check passed.[/green]")
+        else:
+            n_err = len(result.errors)
+            n_warn = len(result.warnings)
+            console.print(f"\n[red]Check failed.[/red] {n_err} error(s), {n_warn} warning(s).")
+
+    if not passed:
+        raise typer.Exit(1)

--- a/src/lattice_lens/cli/main.py
+++ b/src/lattice_lens/cli/main.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import typer
 
 from lattice_lens.cli.backend_command import backend_app
+from lattice_lens.cli.check_command import check
 from lattice_lens.cli.context_commands import context
 from lattice_lens.cli.evaluate_command import evaluate
 from lattice_lens.cli.exchange_commands import export_cmd, import_cmd
@@ -32,6 +33,7 @@ app.add_typer(fact_app, name="fact", help="Manage facts (add, get, ls, edit, pro
 app.add_typer(graph_app, name="graph", help="Knowledge graph analysis.")
 app.add_typer(backend_app, name="backend", help="Backend management (status, switch).")
 app.command()(init)
+app.command()(check)
 app.command()(validate)
 app.command()(reindex)
 app.command()(seed)

--- a/src/lattice_lens/services/check_service.py
+++ b/src/lattice_lens/services/check_service.py
@@ -1,0 +1,128 @@
+"""CI check engine — composes validation + reconciliation into a single pass/fail."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from lattice_lens.services.validate_service import validate_lattice
+from lattice_lens.store.protocol import LatticeStore
+
+
+@dataclass
+class CheckItem:
+    """A single check finding with optional file location for CI annotations."""
+
+    message: str
+    file: str | None = None
+    line: int | None = None
+
+
+@dataclass
+class CheckResult:
+    """Aggregated result from all check phases."""
+
+    errors: list[CheckItem] = field(default_factory=list)
+    warnings: list[CheckItem] = field(default_factory=list)
+    coverage_pct: float | None = None  # None if reconciliation not run
+
+    @property
+    def ok(self) -> bool:
+        return len(self.errors) == 0
+
+    def failed(self, strict: bool = False) -> bool:
+        """Return True if the check should fail.
+
+        In strict mode, any warning is also a failure.
+        """
+        if self.errors:
+            return True
+        if strict and self.warnings:
+            return True
+        return False
+
+
+_STALE_MARKER = "is stale"
+
+
+def run_check(
+    store: LatticeStore,
+    *,
+    stale_is_error: bool = False,
+    reconcile_path: Path | None = None,
+    include_patterns: list[str] | None = None,
+    exclude_patterns: list[str] | None = None,
+    min_coverage: int = 0,
+) -> CheckResult:
+    """Run all checks and return a structured result.
+
+    Composes validate_lattice() and optionally reconcile() into a single
+    CheckResult suitable for CI gating.
+    """
+    result = CheckResult()
+
+    # --- Phase 1: Integrity validation ---
+    val = validate_lattice(store.facts_dir)
+
+    for msg in val.errors:
+        result.errors.append(CheckItem(message=msg))
+
+    for msg in val.warnings:
+        if stale_is_error and _STALE_MARKER in msg.lower():
+            result.errors.append(CheckItem(message=msg))
+        else:
+            result.warnings.append(CheckItem(message=msg))
+
+    # --- Phase 2: Reconciliation (optional) ---
+    if reconcile_path is not None:
+        from lattice_lens.services.reconcile_service import reconcile
+
+        report = reconcile(
+            store,
+            reconcile_path,
+            include_patterns=include_patterns,
+            exclude_patterns=exclude_patterns,
+        )
+
+        result.coverage_pct = report.coverage_pct
+
+        # Violated findings are errors
+        for finding in report.violated:
+            result.errors.append(
+                CheckItem(
+                    message=f"Violated: {finding.code} — {finding.description}",
+                    file=finding.file,
+                    line=finding.line,
+                )
+            )
+
+        # Orphaned facts are warnings (no code evidence)
+        for finding in report.orphaned:
+            result.warnings.append(
+                CheckItem(
+                    message=f"Orphaned: {finding.code} — {finding.description}",
+                )
+            )
+
+        # Untracked patterns are warnings
+        for finding in report.untracked:
+            result.warnings.append(
+                CheckItem(
+                    message=f"Untracked: {finding.description}",
+                    file=finding.file,
+                    line=finding.line,
+                )
+            )
+
+        # Coverage gate
+        if min_coverage > 0 and report.coverage_pct < min_coverage:
+            result.errors.append(
+                CheckItem(
+                    message=(
+                        f"Coverage {report.coverage_pct:.1f}% is below "
+                        f"minimum threshold {min_coverage}%"
+                    ),
+                )
+            )
+
+    return result

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -1,0 +1,239 @@
+"""Tests for lattice check — CI gate command."""
+
+from __future__ import annotations
+
+import json
+from datetime import date, timedelta
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from lattice_lens.cli.main import app
+from lattice_lens.config import FACTS_DIR, HISTORY_DIR, LATTICE_DIR, ROLES_DIR
+from lattice_lens.services.check_service import CheckItem, CheckResult, run_check
+from lattice_lens.store.yaml_store import YamlFileStore
+from tests.conftest import make_fact
+
+runner = CliRunner()
+
+
+def _setup_lattice(tmp_path: Path) -> Path:
+    """Create a minimal .lattice/ directory."""
+    lattice_root = tmp_path / LATTICE_DIR
+    (lattice_root / FACTS_DIR).mkdir(parents=True)
+    (lattice_root / ROLES_DIR).mkdir(parents=True)
+    (lattice_root / HISTORY_DIR).mkdir(parents=True)
+    (lattice_root / "config.yaml").write_text("version: 0.5.0\nbackend: yaml\n")
+    return lattice_root
+
+
+def _add_fact(lattice_root: Path, fact):
+    store = YamlFileStore(lattice_root)
+    store.create(fact)
+
+
+# ── Service-level tests ──
+
+
+class TestCheckResult:
+    def test_ok_when_no_errors(self):
+        r = CheckResult()
+        assert r.ok
+        assert not r.failed()
+
+    def test_not_ok_with_errors(self):
+        r = CheckResult(errors=[CheckItem(message="bad")])
+        assert not r.ok
+        assert r.failed()
+
+    def test_strict_fails_on_warnings(self):
+        r = CheckResult(warnings=[CheckItem(message="warn")])
+        assert r.ok
+        assert not r.failed(strict=False)
+        assert r.failed(strict=True)
+
+
+class TestRunCheck:
+    def test_clean_lattice_passes(self, yaml_store: YamlFileStore):
+        fact = make_fact(code="ADR-01")
+        yaml_store.create(fact)
+        result = run_check(yaml_store)
+        assert result.ok
+
+    def test_validation_error_detected(self, yaml_store: YamlFileStore):
+        # Write a malformed YAML file
+        bad = yaml_store.facts_dir / "BAD-01.yaml"
+        bad.write_text("{{invalid yaml: [")
+        result = run_check(yaml_store)
+        assert not result.ok
+        assert any("YAML parse error" in e.message or "Validation error" in e.message
+                    for e in result.errors)
+
+    def test_stale_is_warning_by_default(self, yaml_store: YamlFileStore):
+        fact = make_fact(code="ADR-01", review_by=date.today() - timedelta(days=1))
+        yaml_store.create(fact)
+        result = run_check(yaml_store)
+        assert result.ok  # stale is a warning, not error
+        assert any("stale" in w.message.lower() for w in result.warnings)
+
+    def test_stale_is_error_when_flag_set(self, yaml_store: YamlFileStore):
+        fact = make_fact(code="ADR-01", review_by=date.today() - timedelta(days=1))
+        yaml_store.create(fact)
+        result = run_check(yaml_store, stale_is_error=True)
+        assert not result.ok
+        assert any("stale" in e.message.lower() for e in result.errors)
+
+    def test_reconcile_computes_coverage(self, yaml_store: YamlFileStore, tmp_path):
+        fact = make_fact(code="ADR-01")
+        yaml_store.create(fact)
+
+        # Create source file referencing the fact
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "app.py").write_text("# ADR-01: architecture decision\n")
+
+        result = run_check(yaml_store, reconcile_path=src)
+        assert result.coverage_pct is not None
+
+    def test_min_coverage_enforced(self, yaml_store: YamlFileStore, tmp_path):
+        fact = make_fact(code="ADR-01")
+        yaml_store.create(fact)
+
+        # Source with no references → 0% coverage
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "app.py").write_text("# nothing here\n")
+
+        result = run_check(yaml_store, reconcile_path=src, min_coverage=80)
+        assert not result.ok
+        assert any("coverage" in e.message.lower() for e in result.errors)
+
+    def test_no_coverage_pct_without_reconcile(self, yaml_store: YamlFileStore):
+        fact = make_fact(code="ADR-01")
+        yaml_store.create(fact)
+        result = run_check(yaml_store)
+        assert result.coverage_pct is None
+
+
+# ── CLI-level tests ──
+
+
+class TestCheckCli:
+    def test_check_clean_lattice(self, tmp_path, monkeypatch):
+        lattice_root = _setup_lattice(tmp_path)
+        _add_fact(lattice_root, make_fact(code="ADR-01"))
+        monkeypatch.chdir(tmp_path)
+        result = runner.invoke(app, ["check"])
+        assert result.exit_code == 0
+        assert "passed" in result.output.lower()
+
+    def test_check_validation_error_exits_1(self, tmp_path, monkeypatch):
+        lattice_root = _setup_lattice(tmp_path)
+        bad = lattice_root / FACTS_DIR / "BAD-01.yaml"
+        bad.write_text("{{invalid yaml: [")
+        monkeypatch.chdir(tmp_path)
+        result = runner.invoke(app, ["check"])
+        assert result.exit_code == 1
+        assert "failed" in result.output.lower()
+
+    def test_check_strict_fails_on_warnings(self, tmp_path, monkeypatch):
+        lattice_root = _setup_lattice(tmp_path)
+        _add_fact(
+            lattice_root,
+            make_fact(code="ADR-01", review_by=date.today() - timedelta(days=1)),
+        )
+        monkeypatch.chdir(tmp_path)
+
+        # Without strict → passes (stale is just a warning)
+        result = runner.invoke(app, ["check"])
+        assert result.exit_code == 0
+
+        # With strict → fails
+        result = runner.invoke(app, ["check", "--strict"])
+        assert result.exit_code == 1
+
+    def test_check_stale_is_error_flag(self, tmp_path, monkeypatch):
+        lattice_root = _setup_lattice(tmp_path)
+        _add_fact(
+            lattice_root,
+            make_fact(code="ADR-01", review_by=date.today() - timedelta(days=1)),
+        )
+        monkeypatch.chdir(tmp_path)
+        result = runner.invoke(app, ["check", "--stale-is-error"])
+        assert result.exit_code == 1
+
+    def test_check_json_output(self, tmp_path, monkeypatch):
+        lattice_root = _setup_lattice(tmp_path)
+        _add_fact(lattice_root, make_fact(code="ADR-01"))
+        monkeypatch.chdir(tmp_path)
+        result = runner.invoke(app, ["check", "--format", "json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["passed"] is True
+        assert isinstance(data["errors"], list)
+        assert isinstance(data["warnings"], list)
+
+    def test_check_github_format(self, tmp_path, monkeypatch):
+        lattice_root = _setup_lattice(tmp_path)
+        # Add a stale fact to trigger a warning
+        _add_fact(
+            lattice_root,
+            make_fact(code="ADR-01", review_by=date.today() - timedelta(days=1)),
+        )
+        monkeypatch.chdir(tmp_path)
+        result = runner.invoke(app, ["check", "--format", "github"])
+        assert result.exit_code == 0
+        assert "::warning" in result.output
+
+    def test_check_github_format_errors(self, tmp_path, monkeypatch):
+        lattice_root = _setup_lattice(tmp_path)
+        bad = lattice_root / FACTS_DIR / "BAD-01.yaml"
+        bad.write_text("{{invalid yaml: [")
+        monkeypatch.chdir(tmp_path)
+        result = runner.invoke(app, ["check", "--format", "github"])
+        assert result.exit_code == 1
+        assert "::error" in result.output
+
+    def test_check_no_lattice(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        result = runner.invoke(app, ["check"])
+        assert result.exit_code == 1
+
+    def test_check_min_coverage_requires_reconcile(self, tmp_path, monkeypatch):
+        lattice_root = _setup_lattice(tmp_path)
+        _add_fact(lattice_root, make_fact(code="ADR-01"))
+        monkeypatch.chdir(tmp_path)
+        result = runner.invoke(app, ["check", "--min-coverage", "80"])
+        assert result.exit_code == 1
+        assert "requires" in result.output.lower()
+
+    def test_check_with_reconcile(self, tmp_path, monkeypatch):
+        lattice_root = _setup_lattice(tmp_path)
+        _add_fact(lattice_root, make_fact(code="ADR-01"))
+
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "app.py").write_text("# ADR-01 reference\n")
+
+        monkeypatch.chdir(tmp_path)
+        result = runner.invoke(
+            app, ["check", "--reconcile", str(src)]
+        )
+        assert result.exit_code == 0
+
+    def test_check_json_with_reconcile(self, tmp_path, monkeypatch):
+        lattice_root = _setup_lattice(tmp_path)
+        _add_fact(lattice_root, make_fact(code="ADR-01"))
+
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "app.py").write_text("# ADR-01 reference\n")
+
+        monkeypatch.chdir(tmp_path)
+        result = runner.invoke(
+            app, ["check", "--reconcile", str(src), "--format", "json"]
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert "coverage_pct" in data
+        assert data["coverage_pct"] is not None


### PR DESCRIPTION
## Summary
- Adds `lattice check` command that composes validation + reconciliation into a single CI gate with exit code 0 (pass) or 1 (fail)
- Supports `--strict` (warnings = failure), `--stale-is-error`, `--reconcile PATH`, `--min-coverage N`, and `--format text|json|github`
- GitHub Actions annotation format (`::error`/`::warning`) for native CI integration
- Config-file defaults in `.lattice/config.yaml` under `check:` key so CI can just run `lattice check`

## Test plan
- [x] 21 new tests covering service logic and CLI behavior (all passing)
- [x] Full test suite passes (361 passed, 1 skipped)
- [x] Manual verification against live project lattice in all output formats
- [x] Verified `--strict` correctly fails on warnings, `--stale-is-error` promotes stale to errors
- [x] Verified `--min-coverage` requires `--reconcile` and gates on coverage percentage

🤖 Generated with [Claude Code](https://claude.com/claude-code)