### PR TITLE
Add typed edges and context graph expansion (Layer 4)

### DIFF
--- a/.lattice/config.yaml
+++ b/.lattice/config.yaml
@@ -1,4 +1,4 @@
-version: 0.4.0
+version: 0.7.0
 backend: yaml
 auto_promote:
   enabled: false

--- a/.lattice/facts/ADR-01.yaml
+++ b/.lattice/facts/ADR-01.yaml
@@ -13,8 +13,10 @@ status: Active
 confidence: Confirmed
 version: 2
 refs:
-- DES-01
-- SP-01
+- code: DES-01
+  rel: drives
+- code: SP-01
+  rel: drives
 superseded_by:
 owner: architecture-team
 review_by: '2026-09-01'

--- a/.lattice/facts/ADR-02.yaml
+++ b/.lattice/facts/ADR-02.yaml
@@ -13,8 +13,10 @@ status: Active
 confidence: Confirmed
 version: 1
 refs:
-- ADR-03
-- DG-01
+- code: ADR-03
+  rel: relates
+- code: DG-01
+  rel: mitigates
 superseded_by:
 owner: architecture-team
 review_by: '2026-09-01'

--- a/.lattice/facts/ADR-03.yaml
+++ b/.lattice/facts/ADR-03.yaml
@@ -15,9 +15,12 @@ status: Active
 confidence: Confirmed
 version: 1
 refs:
-- ADR-02
-- DES-01
-- DES-02
+- code: ADR-02
+  rel: relates
+- code: DES-01
+  rel: drives
+- code: DES-02
+  rel: drives
 superseded_by:
 owner: architecture-team
 review_by: '2026-09-01'

--- a/.lattice/facts/ADR-04.yaml
+++ b/.lattice/facts/ADR-04.yaml
@@ -14,9 +14,12 @@ status: Active
 confidence: Confirmed
 version: 1
 refs:
-- DG-01
-- RISK-01
-- SP-01
+- code: DG-01
+  rel: mitigates
+- code: RISK-01
+  rel: mitigates
+- code: SP-01
+  rel: drives
 superseded_by:
 owner: architecture-team
 review_by: '2026-09-01'

--- a/.lattice/facts/ADR-05.yaml
+++ b/.lattice/facts/ADR-05.yaml
@@ -14,7 +14,8 @@ status: Active
 confidence: Confirmed
 version: 1
 refs:
-- PRD-01
+- code: PRD-01
+  rel: relates
 superseded_by:
 owner: architecture-team
 review_by: '2026-12-01'

--- a/.lattice/facts/ADR-06.yaml
+++ b/.lattice/facts/ADR-06.yaml
@@ -14,9 +14,12 @@ status: Active
 confidence: Confirmed
 version: 1
 refs:
-- DES-01
-- MC-01
-- MON-01
+- code: DES-01
+  rel: drives
+- code: MC-01
+  rel: mitigates
+- code: MON-01
+  rel: drives
 superseded_by:
 owner: architecture-team
 review_by: '2026-09-01'

--- a/.lattice/facts/ADR-07.yaml
+++ b/.lattice/facts/ADR-07.yaml
@@ -14,8 +14,10 @@ status: Active
 confidence: Confirmed
 version: 1
 refs:
-- ADR-03
-- ADR-02
+- code: ADR-03
+  rel: relates
+- code: ADR-02
+  rel: relates
 superseded_by:
 owner: architecture-team
 review_by: '2026-09-01'

--- a/.lattice/facts/ADR-08.yaml
+++ b/.lattice/facts/ADR-08.yaml
@@ -14,8 +14,10 @@ status: Active
 confidence: Confirmed
 version: 1
 refs:
-- ADR-01
-- DES-01
+- code: ADR-01
+  rel: relates
+- code: DES-01
+  rel: drives
 superseded_by:
 owner: architecture-team
 review_by: '2026-09-01'

--- a/.lattice/facts/ADR-09.yaml
+++ b/.lattice/facts/ADR-09.yaml
@@ -15,8 +15,10 @@ status: Active
 confidence: Confirmed
 version: 1
 refs:
-- RUN-01
-- PRD-01
+- code: RUN-01
+  rel: drives
+- code: PRD-01
+  rel: relates
 superseded_by:
 owner: architecture-team
 review_by: '2026-09-01'

--- a/.lattice/facts/ADR-10.yaml
+++ b/.lattice/facts/ADR-10.yaml
@@ -15,9 +15,12 @@ status: Active
 confidence: Confirmed
 version: 1
 refs:
-- DES-01
-- SP-03
-- PRD-01
+- code: DES-01
+  rel: drives
+- code: SP-03
+  rel: drives
+- code: PRD-01
+  rel: relates
 superseded_by:
 owner: architecture-team
 review_by: '2026-09-01'

--- a/.lattice/facts/ADR-11.yaml
+++ b/.lattice/facts/ADR-11.yaml
@@ -15,8 +15,10 @@ status: Active
 confidence: Confirmed
 version: 1
 refs:
-- ADR-03
-- ADR-07
+- code: ADR-03
+  rel: relates
+- code: ADR-07
+  rel: relates
 superseded_by:
 owner: architecture-team
 review_by: '2026-09-01'

--- a/.lattice/facts/ADR-12.yaml
+++ b/.lattice/facts/ADR-12.yaml
@@ -16,8 +16,10 @@ status: Active
 confidence: Confirmed
 version: 1
 refs:
-- ADR-04
-- PRD-01
+- code: ADR-04
+  rel: relates
+- code: PRD-01
+  rel: relates
 superseded_by:
 owner: architecture-team
 review_by: '2026-12-01'

--- a/.lattice/facts/ADR-13.yaml
+++ b/.lattice/facts/ADR-13.yaml
@@ -16,8 +16,10 @@ status: Active
 confidence: Confirmed
 version: 1
 refs:
-- PRD-01
-- PRD-02
+- code: PRD-01
+  rel: relates
+- code: PRD-02
+  rel: relates
 superseded_by:
 owner: architecture-team
 review_by: '2026-12-01'

--- a/.lattice/facts/ADR-14.yaml
+++ b/.lattice/facts/ADR-14.yaml
@@ -15,8 +15,10 @@ status: Active
 confidence: Confirmed
 version: 3
 refs:
-- ADR-03
-- ADR-12
+- code: ADR-03
+  rel: relates
+- code: ADR-12
+  rel: relates
 superseded_by:
 owner: architecture-team
 review_by: '2026-06-01'

--- a/.lattice/facts/ADR-15.yaml
+++ b/.lattice/facts/ADR-15.yaml
@@ -16,10 +16,14 @@ status: Active
 confidence: Confirmed
 version: 3
 refs:
-- ADR-03
-- ADR-04
-- AUP-02
-- AUP-05
+- code: ADR-03
+  rel: relates
+- code: ADR-04
+  rel: relates
+- code: AUP-02
+  rel: mitigates
+- code: AUP-05
+  rel: mitigates
 superseded_by:
 owner: architecture-team
 review_by: '2026-06-01'

--- a/.lattice/facts/ADR-16.yaml
+++ b/.lattice/facts/ADR-16.yaml
@@ -1,31 +1,56 @@
-code: ADR-16
-layer: WHY
-type: Architecture Decision Record
-fact: SQLite (Python stdlib sqlite3) is chosen as the Tier 2 storage backend for
-  lattices that outgrow YAML flat files. SQLite requires zero additional 
-  dependencies, uses WAL mode for concurrent read access, and supports indexed 
-  queries scaling from 500 to 100K facts. The LatticeStore protocol abstraction 
-  means all CLI commands, MCP tools, and services work without modification 
-  regardless of backend. SQLite trades git-native per-fact diffs for query 
-  performance — the export command and changelog table preserve auditability.
-tags:
-- architecture
-- scaling
-- sqlite
-- storage
-- zero-dependency
-status: Active
-confidence: Confirmed
-version: 3
-refs:
-- DES-06
-- DES-11
-- ADR-03
-- RISK-02
-- RISK-06
-superseded_by:
-owner: architecture-team
-review_by: '2026-09-01'
-created_at: '2026-03-05T23:55:13.011144'
-updated_at: '2026-03-07T11:23:14.716063'
-projects: []
+code: ADR-16
+
+layer: WHY
+
+type: Architecture Decision Record
+
+fact: "SQLite (Python stdlib sqlite3) is chosen as the Tier 2 storage backend for\n\
+  lattices that outgrow YAML flat files. SQLite requires zero additional\ndependencies,
+  uses WAL mode for concurrent read access, and supports indexed\nqueries scaling
+  from 500 to 100K facts. The LatticeStore protocol abstraction\nmeans all CLI commands,
+  MCP tools, and services work without modification\nregardless of backend. SQLite
+  trades git-native per-fact diffs for query\nperformance — the export command and
+  changelog table preserve auditability."
+
+tags:
+
+- architecture
+
+- scaling
+
+- sqlite
+
+- storage
+
+- zero-dependency
+
+status: Active
+
+confidence: Confirmed
+
+version: 3
+
+refs:
+
+- code: DES-06
+  rel: drives
+- code: DES-11
+  rel: drives
+- code: ADR-03
+  rel: relates
+- code: RISK-02
+  rel: mitigates
+- code: RISK-06
+  rel: mitigates
+superseded_by:
+
+owner: architecture-team
+
+review_by: '2026-09-01'
+
+created_at: '2026-03-05T23:55:13.011144'
+
+updated_at: '2026-03-07T11:23:14.716063'
+
+projects: []
+

--- a/.lattice/facts/ADR-17.yaml
+++ b/.lattice/facts/ADR-17.yaml
@@ -17,9 +17,12 @@ status: Active
 confidence: Confirmed
 version: 3
 refs:
-- DES-07
-- DES-11
-- DES-12
+- code: DES-07
+  rel: drives
+- code: DES-11
+  rel: drives
+- code: DES-12
+  rel: drives
 superseded_by:
 owner: architecture-team
 review_by: '2026-09-01'

--- a/.lattice/facts/ADR-18.yaml
+++ b/.lattice/facts/ADR-18.yaml
@@ -18,10 +18,14 @@ status: Active
 confidence: Confirmed
 version: 3
 refs:
-- DG-12
-- DG-13
-- DES-09
-- DES-10
+- code: DG-12
+  rel: mitigates
+- code: DG-13
+  rel: mitigates
+- code: DES-09
+  rel: drives
+- code: DES-10
+  rel: drives
 superseded_by:
 owner: architecture-team
 review_by: '2026-09-01'

--- a/.lattice/facts/ADR-19.yaml
+++ b/.lattice/facts/ADR-19.yaml
@@ -1,0 +1,33 @@
+code: ADR-19
+layer: WHY
+type: Architecture Decision Record
+fact: >-
+  Adopted typed edges for fact references using 9 edge types: drives,
+  constrains, mitigates, contradicts, implements, supersedes, validates,
+  depends_on, and relates (default). References are modeled as FactRef objects
+  with code and rel fields. Plain string refs are backward-compatible via a
+  Pydantic field validator that coerces strings to FactRef(code=s,
+  rel=RELATES). The supersedes edge replaces the superseded_by field — the
+  new fact points to the old via a supersedes edge, making the direction
+  natural (new supersedes old). Edge types are inferred during migration using
+  prefix-pair heuristics with layer-pair fallbacks.
+tags:
+- architecture
+- edge-types
+- graph
+- typed-refs
+status: Active
+confidence: Confirmed
+version: 1
+refs:
+- code: DES-13
+  rel: drives
+- code: DG-14
+  rel: drives
+- code: AUP-07
+  rel: drives
+superseded_by:
+owner: architecture-team
+review_by: '2026-09-01'
+created_at: '2026-03-08T01:44:23.845562'
+updated_at: '2026-03-08T01:44:23.845562'

--- a/.lattice/facts/API-01.yaml
+++ b/.lattice/facts/API-01.yaml
@@ -13,8 +13,10 @@ status: Active
 confidence: Confirmed
 version: 1
 refs:
-- DES-02
-- ADR-03
+- code: DES-02
+  rel: implements
+- code: ADR-03
+  rel: implements
 superseded_by:
 owner: architecture-team
 review_by:

--- a/.lattice/facts/API-02.yaml
+++ b/.lattice/facts/API-02.yaml
@@ -17,10 +17,14 @@ status: Active
 confidence: Confirmed
 version: 2
 refs:
-- SP-04
-- SP-05
-- DES-04
-- ADR-10
+- code: SP-04
+  rel: depends_on
+- code: SP-05
+  rel: depends_on
+- code: DES-04
+  rel: implements
+- code: ADR-10
+  rel: implements
 superseded_by:
 owner: architecture-team
 review_by: '2026-09-01'

--- a/.lattice/facts/API-03.yaml
+++ b/.lattice/facts/API-03.yaml
@@ -17,10 +17,14 @@ status: Active
 confidence: Confirmed
 version: 3
 refs:
-- DES-11
-- DES-12
-- SP-10
-- API-01
+- code: DES-11
+  rel: implements
+- code: DES-12
+  rel: implements
+- code: SP-10
+  rel: depends_on
+- code: API-01
+  rel: depends_on
 superseded_by:
 owner: architecture-team
 review_by: '2026-09-01'

--- a/.lattice/facts/AUP-01.yaml
+++ b/.lattice/facts/AUP-01.yaml
@@ -13,8 +13,10 @@ status: Active
 confidence: Confirmed
 version: 1
 refs:
-- DG-01
-- ADR-03
+- code: DG-01
+  rel: relates
+- code: ADR-03
+  rel: constrains
 superseded_by:
 owner: architecture-team
 review_by:

--- a/.lattice/facts/AUP-02.yaml
+++ b/.lattice/facts/AUP-02.yaml
@@ -14,8 +14,10 @@ status: Active
 confidence: Confirmed
 version: 1
 refs:
-- ADR-04
-- DG-01
+- code: ADR-04
+  rel: constrains
+- code: DG-01
+  rel: relates
 superseded_by:
 owner: architecture-team
 review_by:

--- a/.lattice/facts/AUP-03.yaml
+++ b/.lattice/facts/AUP-03.yaml
@@ -14,8 +14,10 @@ status: Active
 confidence: Confirmed
 version: 1
 refs:
-- ADR-04
-- DG-01
+- code: ADR-04
+  rel: constrains
+- code: DG-01
+  rel: relates
 superseded_by:
 owner: architecture-team
 review_by:

--- a/.lattice/facts/AUP-04.yaml
+++ b/.lattice/facts/AUP-04.yaml
@@ -14,8 +14,10 @@ status: Active
 confidence: Confirmed
 version: 1
 refs:
-- ADR-04
-- MC-01
+- code: ADR-04
+  rel: constrains
+- code: MC-01
+  rel: relates
 superseded_by:
 owner: architecture-team
 review_by:

--- a/.lattice/facts/AUP-05.yaml
+++ b/.lattice/facts/AUP-05.yaml
@@ -14,8 +14,10 @@ status: Active
 confidence: Confirmed
 version: 1
 refs:
-- ADR-04
-- DG-01
+- code: ADR-04
+  rel: constrains
+- code: DG-01
+  rel: relates
 superseded_by:
 owner: architecture-team
 review_by:

--- a/.lattice/facts/AUP-06.yaml
+++ b/.lattice/facts/AUP-06.yaml
@@ -16,9 +16,12 @@ status: Active
 confidence: Confirmed
 version: 2
 refs:
-- ADR-05
-- ADR-03
-- MC-01
+- code: ADR-05
+  rel: constrains
+- code: ADR-03
+  rel: constrains
+- code: MC-01
+  rel: relates
 superseded_by:
 owner: architecture-team
 review_by: '2026-09-01'

--- a/.lattice/facts/AUP-07.yaml
+++ b/.lattice/facts/AUP-07.yaml
@@ -1,13 +1,19 @@
 code: AUP-07
 layer: GUARDRAILS
 type: Acceptable Use Policy Rule
-fact: Context assembly must follow priority loading rules. Load all facts with 
-  confidence Confirmed first. Within Confirmed, sort by relevance to agent role 
-  via tag match score. Load Provisional facts only if token budget remains. 
-  Never load Deprecated or Superseded facts. Include REFS pointers even for 
-  facts not loaded, so the agent knows what exists but is not in context. This 
-  ensures agents always receive the highest-quality facts first within their 
-  budget.
+fact: >-
+  Context assembly follows a 6-step pipeline. Step 1: Project filter — scope to
+  active project (global facts always included). Step 2: Role filter — match by
+  layer, type, and extra queries from the role template. Step 3: Tag score —
+  rank by tag overlap with role template tags. Step 4: Graph expansion — if
+  direct matches are fewer than max_facts and graph_depth > 0, BFS-expand along
+  typed edges (prioritized by edge_priority list in role template) to pull in
+  structurally related facts. Step 5: Unified sort — sort all candidates by
+  (confidence_tier, source_type, tag_score, code) where confidence_tier ranks
+  Confirmed above Provisional/stale, and source_type ranks direct matches above
+  graph-pulled facts within the same tier. Step 6: Take top max_facts. Never
+  load Deprecated or Superseded facts. Include REFS pointers even for facts not
+  loaded, so the agent knows what exists but is not in context.
 tags:
 - context-assembly
 - governance
@@ -15,13 +21,16 @@ tags:
 - token-budget
 status: Active
 confidence: Confirmed
-version: 1
+version: 2
 refs:
-- DES-08
-- DG-06
-- DES-01
+- code: DES-08
+  rel: constrains
+- code: DG-06
+  rel: relates
+- code: DES-01
+  rel: constrains
 superseded_by:
 owner: architecture-team
 review_by: '2026-09-01'
 created_at: '2026-03-05T13:06:51.345657'
-updated_at: '2026-03-05T13:06:51.345689'
+updated_at: '2026-03-08T01:31:44.833975'

--- a/.lattice/facts/AUP-08.yaml
+++ b/.lattice/facts/AUP-08.yaml
@@ -17,9 +17,12 @@ status: Deprecated
 confidence: Confirmed
 version: 4
 refs:
-- DG-06
-- DG-04
-- AUP-07
+- code: DG-06
+  rel: relates
+- code: DG-04
+  rel: relates
+- code: AUP-07
+  rel: relates
 superseded_by:
 owner: architecture-team
 review_by: '2026-09-01'

--- a/.lattice/facts/DES-01.yaml
+++ b/.lattice/facts/DES-01.yaml
@@ -14,8 +14,10 @@ status: Active
 confidence: Confirmed
 version: 1
 refs:
-- ADR-03
-- SP-01
+- code: ADR-03
+  rel: relates
+- code: SP-01
+  rel: drives
 superseded_by:
 owner: architecture-team
 review_by: '2026-09-01'

--- a/.lattice/facts/DES-02.yaml
+++ b/.lattice/facts/DES-02.yaml
@@ -14,8 +14,10 @@ status: Active
 confidence: Confirmed
 version: 1
 refs:
-- ADR-03
-- API-01
+- code: ADR-03
+  rel: relates
+- code: API-01
+  rel: drives
 superseded_by:
 owner: architecture-team
 review_by: '2026-09-01'

--- a/.lattice/facts/DES-03.yaml
+++ b/.lattice/facts/DES-03.yaml
@@ -15,8 +15,10 @@ status: Active
 confidence: Confirmed
 version: 1
 refs:
-- DES-01
-- RUN-02
+- code: DES-01
+  rel: depends_on
+- code: RUN-02
+  rel: drives
 superseded_by:
 owner: architecture-team
 review_by: '2026-09-01'

--- a/.lattice/facts/DES-04.yaml
+++ b/.lattice/facts/DES-04.yaml
@@ -15,8 +15,10 @@ status: Active
 confidence: Confirmed
 version: 1
 refs:
-- SP-02
-- DES-01
+- code: SP-02
+  rel: drives
+- code: DES-01
+  rel: depends_on
 superseded_by:
 owner: architecture-team
 review_by: '2026-09-01'

--- a/.lattice/facts/DES-05.yaml
+++ b/.lattice/facts/DES-05.yaml
@@ -16,9 +16,12 @@ status: Active
 confidence: Confirmed
 version: 1
 refs:
-- PRD-01
-- PRD-02
-- DES-01
+- code: PRD-01
+  rel: relates
+- code: PRD-02
+  rel: relates
+- code: DES-01
+  rel: depends_on
 superseded_by:
 owner: architecture-team
 review_by: '2026-09-01'

--- a/.lattice/facts/DES-06.yaml
+++ b/.lattice/facts/DES-06.yaml
@@ -17,9 +17,12 @@ status: Active
 confidence: Confirmed
 version: 1
 refs:
-- DES-02
-- ADR-03
-- PRD-01
+- code: DES-02
+  rel: depends_on
+- code: ADR-03
+  rel: relates
+- code: PRD-01
+  rel: relates
 superseded_by:
 owner: architecture-team
 review_by: '2026-09-01'

--- a/.lattice/facts/DES-07.yaml
+++ b/.lattice/facts/DES-07.yaml
@@ -16,9 +16,12 @@ status: Active
 confidence: Confirmed
 version: 2
 refs:
-- PRD-01
-- DES-05
-- DES-01
+- code: PRD-01
+  rel: relates
+- code: DES-05
+  rel: depends_on
+- code: DES-01
+  rel: depends_on
 superseded_by:
 owner: architecture-team
 review_by: '2026-09-01'

--- a/.lattice/facts/DES-08.yaml
+++ b/.lattice/facts/DES-08.yaml
@@ -17,10 +17,14 @@ status: Active
 confidence: Confirmed
 version: 1
 refs:
-- PRD-01
-- DES-01
-- ADR-10
-- PRD-02
+- code: PRD-01
+  rel: relates
+- code: DES-01
+  rel: depends_on
+- code: ADR-10
+  rel: relates
+- code: PRD-02
+  rel: relates
 superseded_by:
 owner: architecture-team
 review_by: '2026-09-01'

--- a/.lattice/facts/DES-09.yaml
+++ b/.lattice/facts/DES-09.yaml
@@ -1,26 +1,46 @@
-code: DES-09
-layer: WHY
-type: Design Proposal Decision
-fact: A centralized tag registry at .lattice/tags.yaml lists all tags in use 
-  across the lattice with usage counts and vocabulary category assignments. The 
-  registry is generated and refreshable via a lattice tags command — not 
-  hand-edited. Tags are case-insensitive (enforced by existing DG-02 
-  normalization) and deduplicated. The registry serves as the source of truth 
-  for the controlled vocabulary defined in DG-07, replacing the current 
-  documentation-only approach with a queryable, committable artifact.
-tags:
-- controlled-vocabulary
-- design-time
-- developer
-- tag-vocabulary
-status: Active
-confidence: Confirmed
-version: 3
-refs:
-- DG-02
-- DG-07
-superseded_by:
-owner: architecture-team
-review_by:
-created_at: '2026-03-05T20:25:23.591955'
-updated_at: '2026-03-05T22:52:25.678703'
+code: DES-09
+
+layer: WHY
+
+type: Design Proposal Decision
+
+fact: "A centralized tag registry at .lattice/tags.yaml lists all tags in use\nacross
+  the lattice with usage counts and vocabulary category assignments. The\nregistry
+  is generated and refreshable via a lattice tags command — not\nhand-edited. Tags
+  are case-insensitive (enforced by existing DG-02\nnormalization) and deduplicated.
+  The registry serves as the source of truth\nfor the controlled vocabulary defined
+  in DG-07, replacing the current\ndocumentation-only approach with a queryable, committable
+  artifact."
+
+tags:
+
+- controlled-vocabulary
+
+- design-time
+
+- developer
+
+- tag-vocabulary
+
+status: Active
+
+confidence: Confirmed
+
+version: 3
+
+refs:
+
+- code: DG-02
+  rel: mitigates
+- code: DG-07
+  rel: mitigates
+superseded_by:
+
+owner: architecture-team
+
+review_by:
+
+created_at: '2026-03-05T20:25:23.591955'
+
+updated_at: '2026-03-05T22:52:25.678703'
+

--- a/.lattice/facts/DES-10.yaml
+++ b/.lattice/facts/DES-10.yaml
@@ -18,9 +18,12 @@ status: Active
 confidence: Confirmed
 version: 3
 refs:
-- RISK-03
-- ADR-05
-- DG-02
+- code: RISK-03
+  rel: mitigates
+- code: ADR-05
+  rel: relates
+- code: DG-02
+  rel: mitigates
 superseded_by:
 owner: architecture-team
 review_by:

--- a/.lattice/facts/DES-11.yaml
+++ b/.lattice/facts/DES-11.yaml
@@ -20,11 +20,16 @@ status: Active
 confidence: Confirmed
 version: 3
 refs:
-- DES-06
-- DES-07
-- PRD-01
-- RISK-02
-- RISK-06
+- code: DES-06
+  rel: depends_on
+- code: DES-07
+  rel: depends_on
+- code: PRD-01
+  rel: relates
+- code: RISK-02
+  rel: mitigates
+- code: RISK-06
+  rel: mitigates
 superseded_by:
 owner: architecture-team
 review_by: '2026-09-01'

--- a/.lattice/facts/DES-12.yaml
+++ b/.lattice/facts/DES-12.yaml
@@ -1,28 +1,50 @@
-code: DES-12
-layer: WHY
-type: Design Proposal Decision
-fact: 'The reconciliation report uses two dataclasses: Finding (category, code, description,
-  file, line, confidence, evidence) and ReconciliationReport (lists of findings by
-  category plus computed summary). Findings fall into five categories — confirmed
-  (code supports fact), stale (code diverged from fact), violated (code contradicts
-  fact), untracked (code pattern with no fact), and orphaned (active fact with no
-  code evidence). Coverage percentage is calculated as confirmed / total_facts_checked
-  * 100. The report structure supports both Rich table display and JSON serialization.'
-tags:
-- data-model
-- dataclass
-- design
-- reconciliation
-status: Active
-confidence: Confirmed
-version: 3
-refs:
-- DES-07
-- DES-11
-- ADR-17
-superseded_by:
-owner: architecture-team
-review_by: '2026-09-01'
-created_at: '2026-03-05T23:55:36.946253'
-updated_at: '2026-03-07T11:23:16.239276'
-projects: []
+code: DES-12
+
+layer: WHY
+
+type: Design Proposal Decision
+
+fact: "The reconciliation report uses two dataclasses: Finding (category, code, description,\n\
+  file, line, confidence, evidence) and ReconciliationReport (lists of findings by\n\
+  category plus computed summary). Findings fall into five categories — confirmed\n\
+  (code supports fact), stale (code diverged from fact), violated (code contradicts\n\
+  fact), untracked (code pattern with no fact), and orphaned (active fact with no\n\
+  code evidence). Coverage percentage is calculated as confirmed / total_facts_checked\n\
+  * 100. The report structure supports both Rich table display and JSON serialization."
+
+tags:
+
+- data-model
+
+- dataclass
+
+- design
+
+- reconciliation
+
+status: Active
+
+confidence: Confirmed
+
+version: 3
+
+refs:
+
+- code: DES-07
+  rel: depends_on
+- code: DES-11
+  rel: depends_on
+- code: ADR-17
+  rel: relates
+superseded_by:
+
+owner: architecture-team
+
+review_by: '2026-09-01'
+
+created_at: '2026-03-05T23:55:36.946253'
+
+updated_at: '2026-03-07T11:23:16.239276'
+
+projects: []
+

--- a/.lattice/facts/DES-13.yaml
+++ b/.lattice/facts/DES-13.yaml
@@ -1,0 +1,33 @@
+code: DES-13
+layer: WHY
+type: Design Proposal Decision
+fact: >-
+  Context assembly uses demand-driven graph expansion as step 4 of a 6-step
+  pipeline. After project filtering, role filtering, and tag scoring, if direct
+  matches are fewer than max_facts and graph_depth > 0, BFS traversal expands
+  along typed edges from seed facts. Traversal respects edge_priority (ordered
+  list of edge types to follow), excludes Deprecated and Superseded facts, and
+  tracks hop distance. Graph-pulled facts rank below direct matches within the
+  same confidence tier. The graph_depth parameter defaults to 1 (configurable
+  per role template or via --depth CLI flag). Depth 0 disables expansion, depth
+  -1 traverses the full connected component.
+tags:
+- architecture
+- context-assembly
+- graph
+- graph-expansion
+status: Active
+confidence: Confirmed
+version: 1
+refs:
+- code: ADR-19
+  rel: implements
+- code: AUP-07
+  rel: implements
+- code: DES-08
+  rel: depends_on
+superseded_by:
+owner: architecture-team
+review_by: '2026-09-01'
+created_at: '2026-03-08T01:44:23.845562'
+updated_at: '2026-03-08T01:44:23.845562'

--- a/.lattice/facts/DG-01.yaml
+++ b/.lattice/facts/DG-01.yaml
@@ -13,9 +13,12 @@ status: Active
 confidence: Confirmed
 version: 1
 refs:
-- AUP-01
-- ADR-03
-- RUN-01
+- code: AUP-01
+  rel: relates
+- code: ADR-03
+  rel: constrains
+- code: RUN-01
+  rel: constrains
 superseded_by:
 owner: architecture-team
 review_by:

--- a/.lattice/facts/DG-02.yaml
+++ b/.lattice/facts/DG-02.yaml
@@ -14,8 +14,10 @@ status: Active
 confidence: Confirmed
 version: 1
 refs:
-- ADR-04
-- SP-01
+- code: ADR-04
+  rel: constrains
+- code: SP-01
+  rel: constrains
 superseded_by:
 owner: architecture-team
 review_by:

--- a/.lattice/facts/DG-03.yaml
+++ b/.lattice/facts/DG-03.yaml
@@ -14,8 +14,10 @@ status: Active
 confidence: Confirmed
 version: 1
 refs:
-- ADR-04
-- MC-01
+- code: ADR-04
+  rel: constrains
+- code: MC-01
+  rel: relates
 superseded_by:
 owner: architecture-team
 review_by:

--- a/.lattice/facts/DG-04.yaml
+++ b/.lattice/facts/DG-04.yaml
@@ -16,8 +16,10 @@ status: Active
 confidence: Confirmed
 version: 2
 refs:
-- ADR-05
-- SP-01
+- code: ADR-05
+  rel: constrains
+- code: SP-01
+  rel: constrains
 superseded_by:
 owner: architecture-team
 review_by: '2026-09-01'

--- a/.lattice/facts/DG-05.yaml
+++ b/.lattice/facts/DG-05.yaml
@@ -1,25 +1,45 @@
-code: DG-05
-layer: GUARDRAILS
-type: Data Governance Rule
-fact: The changelog at .lattice/changelog.jsonl uses JSON Lines format — one 
-  JSON object per line, append-only. Each entry records action (add, update, 
-  delete), fact code, timestamp, and reason. JSONL is streamable, grep-friendly,
-  and avoids the need to parse an entire file for new appends. The changelog is 
-  written by LatticeStore on every mutation. Full fact state snapshots are not 
-  included — git history on the YAML files themselves serves that purpose.
-tags:
-- append-only
-- audit-trail
-- changelog
-- jsonl
-status: Active
-confidence: Confirmed
-version: 2
-refs:
-- ADR-06
-- DG-01
-superseded_by:
-owner: architecture-team
-review_by: '2026-09-01'
-created_at: '2026-03-05T13:00:32.840045'
-updated_at: '2026-03-05T20:24:37.680067'
+code: DG-05
+
+layer: GUARDRAILS
+
+type: Data Governance Rule
+
+fact: "The changelog at .lattice/changelog.jsonl uses JSON Lines format — one\n\
+  JSON object per line, append-only. Each entry records action (add, update,\ndelete),
+  fact code, timestamp, and reason. JSONL is streamable, grep-friendly,\nand avoids
+  the need to parse an entire file for new appends. The changelog is\nwritten by LatticeStore
+  on every mutation. Full fact state snapshots are not\nincluded — git history on
+  the YAML files themselves serves that purpose."
+
+tags:
+
+- append-only
+
+- audit-trail
+
+- changelog
+
+- jsonl
+
+status: Active
+
+confidence: Confirmed
+
+version: 2
+
+refs:
+
+- code: ADR-06
+  rel: constrains
+- code: DG-01
+  rel: relates
+superseded_by:
+
+owner: architecture-team
+
+review_by: '2026-09-01'
+
+created_at: '2026-03-05T13:00:32.840045'
+
+updated_at: '2026-03-05T20:24:37.680067'
+

--- a/.lattice/facts/DG-06.yaml
+++ b/.lattice/facts/DG-06.yaml
@@ -1,14 +1,18 @@
 code: DG-06
 layer: GUARDRAILS
 type: Data Governance Rule
-fact: 'Facts progress through a defined lifecycle that controls context inclusion.
-  Draft: author creates initial fact, never included in agent context. Under Review:
-  peer validates, may be included with confidence Provisional. Active: enters the
-  live index, primary content of agent context. Deprecated: no longer relevant, excluded
-  from queries but preserved for audit. Superseded: replaced by a newer fact, must
-  point to replacement via superseded_by. Review Expired is not a formal FactStatus
-  enum value but a runtime condition: facts past their review_by date are flagged
-  and downgraded to Provisional confidence during context assembly.'
+fact: >-
+  Facts progress through a defined lifecycle that controls context inclusion.
+  Draft: author creates initial fact, never included in agent context. Under
+  Review: peer validates, may be included with confidence Provisional. Active:
+  enters the live index, primary content of agent context. Deprecated: no
+  longer relevant, excluded from queries but preserved for audit. Superseded:
+  replaced by a newer fact — the replacement must point to it via a supersedes
+  edge (inbound from the replacing fact), enforced at command-level and by
+  lattice validate. The legacy superseded_by field is also accepted during
+  validation. Review Expired is not a formal FactStatus enum value but a
+  runtime condition: facts past their review_by date are flagged and
+  downgraded to Provisional confidence during context assembly.
 tags:
 - governance
 - lifecycle
@@ -16,14 +20,18 @@ tags:
 - status
 status: Active
 confidence: Confirmed
-version: 2
+version: 3
 refs:
-- DES-01
-- AUP-01
-- AUP-04
-- DG-04
+- code: DES-01
+  rel: constrains
+- code: AUP-01
+  rel: relates
+- code: AUP-04
+  rel: relates
+- code: DG-04
+  rel: relates
 superseded_by:
 owner: architecture-team
 review_by: '2026-09-01'
 created_at: '2026-03-05T13:06:54.483174'
-updated_at: '2026-03-05T18:11:10.839604'
+updated_at: '2026-03-08T01:44:23.845562'

--- a/.lattice/facts/DG-07.yaml
+++ b/.lattice/facts/DG-07.yaml
@@ -16,9 +16,12 @@ status: Active
 confidence: Confirmed
 version: 1
 refs:
-- DG-02
-- DG-03
-- DES-01
+- code: DG-02
+  rel: relates
+- code: DG-03
+  rel: relates
+- code: DES-01
+  rel: constrains
 superseded_by:
 owner: architecture-team
 review_by: '2026-09-01'

--- a/.lattice/facts/DG-08.yaml
+++ b/.lattice/facts/DG-08.yaml
@@ -1,27 +1,34 @@
 code: DG-08
 layer: GUARDRAILS
 type: Data Governance Rule
-fact: The import overwrite path strips created_at and version from the changes 
-  dict before calling store.update(). This ensures created_at remains immutable 
-  (AUP-05) and version is auto-incremented by the store layer (AUP-03). The 
-  store's update method merges remaining fields into the existing fact, bumps 
-  version by 1, and sets updated_at to now. Pydantic validators still run on the
-  merged result, catching any constraint violations (e.g. Superseded without 
-  superseded_by per AUP-04).
+fact: >-
+  The import overwrite path strips created_at and version from the changes
+  dict before calling store.update(). This ensures created_at remains immutable
+  (AUP-05) and version is auto-incremented by the store layer (AUP-03). The
+  store's update method merges remaining fields into the existing fact, bumps
+  version by 1, and sets updated_at to now. Refs are stored as FactRef objects
+  ({code, rel}) and backward-compatible — plain string refs in imported data
+  are coerced to FactRef with rel=relates. Pydantic validators still run on
+  the merged result, catching any constraint violations (e.g. Superseded
+  without superseded_by per AUP-04).
 tags:
 - compliance
 - data-pipeline
 - import-export
 status: Active
 confidence: Confirmed
-version: 3
+version: 4
 refs:
-- ADR-15
-- AUP-02
-- AUP-03
-- AUP-05
+- code: ADR-15
+  rel: constrains
+- code: AUP-02
+  rel: relates
+- code: AUP-03
+  rel: relates
+- code: AUP-05
+  rel: relates
 superseded_by:
 owner: architecture-team
 review_by: '2026-06-01'
 created_at: '2026-03-05T22:52:15.622507'
-updated_at: '2026-03-05T22:52:26.573540'
+updated_at: '2026-03-08T01:44:23.845562'

--- a/.lattice/facts/DG-09.yaml
+++ b/.lattice/facts/DG-09.yaml
@@ -16,9 +16,12 @@ status: Active
 confidence: Confirmed
 version: 3
 refs:
-- DES-09
-- DG-02
-- DG-07
+- code: DES-09
+  rel: constrains
+- code: DG-02
+  rel: relates
+- code: DG-07
+  rel: relates
 superseded_by:
 owner: architecture-team
 review_by:

--- a/.lattice/facts/DG-10.yaml
+++ b/.lattice/facts/DG-10.yaml
@@ -18,9 +18,12 @@ status: Active
 confidence: Confirmed
 version: 3
 refs:
-- DES-10
-- RISK-03
-- MC-01
+- code: DES-10
+  rel: constrains
+- code: RISK-03
+  rel: relates
+- code: MC-01
+  rel: relates
 superseded_by:
 owner: architecture-team
 review_by:

--- a/.lattice/facts/DG-11.yaml
+++ b/.lattice/facts/DG-11.yaml
@@ -1,30 +1,53 @@
-code: DG-11
-layer: GUARDRAILS
-type: Data Governance Rule
-fact: The SQLite backend maintains a changelog table that mirrors the 
-  append-only JSONL changelog format defined in DG-05. Each mutation (create, 
-  update, deprecate) inserts a row with id (autoincrement), timestamp (ISO), 
-  action, code, and reason. This ensures the audit trail guarantee from DG-01 
-  holds regardless of backend. The changelog table is append-only — rows are 
-  never updated or deleted. When migrating between backends, the changelog is 
-  not migrated (each backend maintains its own log); git history and the JSONL 
-  file provide the canonical audit trail for the YAML era.
-tags:
-- audit-trail
-- data-integrity
-- governance
-- sqlite
-status: Active
-confidence: Confirmed
-version: 3
-refs:
-- DG-01
-- DG-05
-- ADR-16
-- RISK-11
-superseded_by:
-owner: architecture-team
-review_by: '2026-09-01'
-created_at: '2026-03-05T23:56:08.515575'
-updated_at: '2026-03-07T11:23:16.632237'
-projects: []
+code: DG-11
+
+layer: GUARDRAILS
+
+type: Data Governance Rule
+
+fact: "The SQLite backend maintains a changelog table that mirrors the\nappend-only
+  JSONL changelog format defined in DG-05. Each mutation (create,\nupdate, deprecate)
+  inserts a row with id (autoincrement), timestamp (ISO),\naction, code, and reason.
+  This ensures the audit trail guarantee from DG-01\nholds regardless of backend.
+  The changelog table is append-only — rows are\nnever updated or deleted. When
+  migrating between backends, the changelog is\nnot migrated (each backend maintains
+  its own log); git history and the JSONL\nfile provide the canonical audit trail
+  for the YAML era."
+
+tags:
+
+- audit-trail
+
+- data-integrity
+
+- governance
+
+- sqlite
+
+status: Active
+
+confidence: Confirmed
+
+version: 3
+
+refs:
+
+- code: DG-01
+  rel: relates
+- code: DG-05
+  rel: relates
+- code: ADR-16
+  rel: constrains
+- code: RISK-11
+  rel: relates
+superseded_by:
+
+owner: architecture-team
+
+review_by: '2026-09-01'
+
+created_at: '2026-03-05T23:56:08.515575'
+
+updated_at: '2026-03-07T11:23:16.632237'
+
+projects: []
+

--- a/.lattice/facts/DG-12.yaml
+++ b/.lattice/facts/DG-12.yaml
@@ -19,10 +19,14 @@ status: Active
 confidence: Confirmed
 version: 3
 refs:
-- ADR-18
-- DG-13
-- MC-01
-- DG-02
+- code: ADR-18
+  rel: constrains
+- code: DG-13
+  rel: relates
+- code: MC-01
+  rel: relates
+- code: DG-02
+  rel: relates
 superseded_by:
 owner: architecture-team
 review_by: '2026-09-01'

--- a/.lattice/facts/DG-13.yaml
+++ b/.lattice/facts/DG-13.yaml
@@ -18,10 +18,14 @@ status: Active
 confidence: Confirmed
 version: 3
 refs:
-- ADR-18
-- DG-12
-- AUP-06
-- MC-01
+- code: ADR-18
+  rel: constrains
+- code: DG-12
+  rel: relates
+- code: AUP-06
+  rel: relates
+- code: MC-01
+  rel: relates
 superseded_by:
 owner: architecture-team
 review_by: '2026-09-01'

--- a/.lattice/facts/DG-14.yaml
+++ b/.lattice/facts/DG-14.yaml
@@ -1,0 +1,35 @@
+code: DG-14
+layer: GUARDRAILS
+type: Data Governance Rule
+fact: >-
+  The edge type vocabulary defines 9 relationship types for fact references.
+  drives: source motivates or requires target. constrains: source limits or
+  restricts target. mitigates: source reduces risk identified in target.
+  contradicts: source conflicts with target. implements: source realizes or
+  fulfills target. supersedes: source replaces target (target becomes
+  Superseded). validates: source confirms or monitors target. depends_on:
+  source requires target to function. relates: generic association (default).
+  Each fact reference must specify exactly one edge type. The lattice validate
+  command checks that Superseded facts have either a superseded_by field or an
+  inbound supersedes edge. Edge types are stored as FactRef objects in YAML
+  ({code: X, rel: type}) and as a rel_type column in SQLite.
+tags:
+- edge-types
+- governance
+- graph
+- validation
+status: Active
+confidence: Confirmed
+version: 1
+refs:
+- code: ADR-19
+  rel: implements
+- code: DG-06
+  rel: relates
+- code: AUP-04
+  rel: relates
+superseded_by:
+owner: architecture-team
+review_by: '2026-09-01'
+created_at: '2026-03-08T01:44:23.845562'
+updated_at: '2026-03-08T01:44:23.845562'

--- a/.lattice/facts/MC-01.yaml
+++ b/.lattice/facts/MC-01.yaml
@@ -14,8 +14,10 @@ status: Active
 confidence: Confirmed
 version: 1
 refs:
-- ADR-04
-- SP-01
+- code: ADR-04
+  rel: constrains
+- code: SP-01
+  rel: constrains
 superseded_by:
 owner: architecture-team
 review_by:

--- a/.lattice/facts/MC-02.yaml
+++ b/.lattice/facts/MC-02.yaml
@@ -15,9 +15,12 @@ status: Active
 confidence: Confirmed
 version: 2
 refs:
-- ADR-03
-- MC-01
-- SP-01
+- code: ADR-03
+  rel: constrains
+- code: MC-01
+  rel: relates
+- code: SP-01
+  rel: constrains
 superseded_by:
 owner: architecture-team
 review_by: '2026-09-01'

--- a/.lattice/facts/MON-01.yaml
+++ b/.lattice/facts/MON-01.yaml
@@ -13,9 +13,12 @@ status: Active
 confidence: Confirmed
 version: 1
 refs:
-- RISK-01
-- MC-01
-- ADR-04
+- code: RISK-01
+  rel: validates
+- code: MC-01
+  rel: validates
+- code: ADR-04
+  rel: implements
 superseded_by:
 owner: architecture-team
 review_by:

--- a/.lattice/facts/PRD-01.yaml
+++ b/.lattice/facts/PRD-01.yaml
@@ -14,10 +14,14 @@ status: Active
 confidence: Confirmed
 version: 2
 refs:
-- DES-01
-- DES-06
-- DES-07
-- DES-11
+- code: DES-01
+  rel: drives
+- code: DES-06
+  rel: drives
+- code: DES-07
+  rel: drives
+- code: DES-11
+  rel: drives
 superseded_by:
 owner: product-team
 review_by: '2026-12-01'

--- a/.lattice/facts/PRD-02.yaml
+++ b/.lattice/facts/PRD-02.yaml
@@ -16,8 +16,10 @@ status: Active
 confidence: Confirmed
 version: 1
 refs:
-- PRD-01
-- DES-02
+- code: PRD-01
+  rel: relates
+- code: DES-02
+  rel: drives
 superseded_by:
 owner: architecture-team
 review_by: '2026-09-01'

--- a/.lattice/facts/PRD-03.yaml
+++ b/.lattice/facts/PRD-03.yaml
@@ -17,11 +17,16 @@ status: Active
 confidence: Confirmed
 version: 3
 refs:
-- DG-06
-- AUP-08
-- AUP-07
-- DES-08
-- PRD-01
+- code: DG-06
+  rel: mitigates
+- code: AUP-08
+  rel: mitigates
+- code: AUP-07
+  rel: mitigates
+- code: DES-08
+  rel: drives
+- code: PRD-01
+  rel: relates
 superseded_by:
 owner: architecture-team
 review_by: '2026-09-01'

--- a/.lattice/facts/PRD-04.yaml
+++ b/.lattice/facts/PRD-04.yaml
@@ -16,9 +16,12 @@ status: Active
 confidence: Confirmed
 version: 3
 refs:
-- PRD-01
-- SP-10
-- SP-11
+- code: PRD-01
+  rel: relates
+- code: SP-10
+  rel: drives
+- code: SP-11
+  rel: drives
 superseded_by:
 owner: product-team
 review_by: '2026-09-01'

--- a/.lattice/facts/RISK-01.yaml
+++ b/.lattice/facts/RISK-01.yaml
@@ -14,8 +14,10 @@ status: Active
 confidence: Confirmed
 version: 2
 refs:
-- ADR-04
-- MON-01
+- code: ADR-04
+  rel: constrains
+- code: MON-01
+  rel: constrains
 superseded_by:
 owner: architecture-team
 review_by:

--- a/.lattice/facts/RISK-02.yaml
+++ b/.lattice/facts/RISK-02.yaml
@@ -14,8 +14,10 @@ status: Active
 confidence: Confirmed
 version: 3
 refs:
-- DES-02
-- ADR-03
+- code: DES-02
+  rel: constrains
+- code: ADR-03
+  rel: constrains
 superseded_by:
 owner: architecture-team
 review_by:

--- a/.lattice/facts/RISK-03.yaml
+++ b/.lattice/facts/RISK-03.yaml
@@ -15,9 +15,12 @@ status: Active
 confidence: Confirmed
 version: 1
 refs:
-- ADR-05
-- DES-04
-- ADR-10
+- code: ADR-05
+  rel: constrains
+- code: DES-04
+  rel: constrains
+- code: ADR-10
+  rel: constrains
 superseded_by:
 owner: architecture-team
 review_by: '2026-09-01'

--- a/.lattice/facts/RISK-04.yaml
+++ b/.lattice/facts/RISK-04.yaml
@@ -15,8 +15,10 @@ status: Active
 confidence: Confirmed
 version: 1
 refs:
-- DES-04
-- ADR-05
+- code: DES-04
+  rel: constrains
+- code: ADR-05
+  rel: constrains
 superseded_by:
 owner: architecture-team
 review_by: '2026-09-01'

--- a/.lattice/facts/RISK-05.yaml
+++ b/.lattice/facts/RISK-05.yaml
@@ -15,8 +15,10 @@ status: Active
 confidence: Confirmed
 version: 2
 refs:
-- ADR-05
-- ADR-12
+- code: ADR-05
+  rel: constrains
+- code: ADR-12
+  rel: constrains
 superseded_by:
 owner: architecture-team
 review_by: '2026-09-01'

--- a/.lattice/facts/RISK-06.yaml
+++ b/.lattice/facts/RISK-06.yaml
@@ -1,27 +1,48 @@
-code: RISK-06
-layer: GUARDRAILS
-type: Risk Register Entry
-fact: Storage tier promotion is planned to use advisory thresholds — warn at 
-  1,500 facts, suggest upgrade at 2,000 — but this is not yet implemented. The 
-  system must never auto-migrate. The developer always decides when to move 
-  between tiers. Forced migration would violate the portability principle and 
-  risk data loss. Future implementation should print a performance advisory at 
-  the warning threshold and a concrete upgrade suggestion at the promotion 
-  threshold, but take no action without explicit user command.
-tags:
-- auto-promote
-- risk
-- storage-tiers
-- thresholds
-status: Active
-confidence: Confirmed
-version: 5
-refs:
-- DES-06
-- DES-02
-- RISK-02
-superseded_by:
-owner: architecture-team
-review_by: '2026-09-01'
-created_at: '2026-03-05T13:06:56.192012'
-updated_at: '2026-03-05T22:52:27.897378'
+code: RISK-06
+
+layer: GUARDRAILS
+
+type: Risk Register Entry
+
+fact: "Storage tier promotion is planned to use advisory thresholds — warn at\n\
+  1,500 facts, suggest upgrade at 2,000 — but this is not yet implemented. The\n\
+  system must never auto-migrate. The developer always decides when to move\nbetween
+  tiers. Forced migration would violate the portability principle and\nrisk data loss.
+  Future implementation should print a performance advisory at\nthe warning threshold
+  and a concrete upgrade suggestion at the promotion\nthreshold, but take no action
+  without explicit user command."
+
+tags:
+
+- auto-promote
+
+- risk
+
+- storage-tiers
+
+- thresholds
+
+status: Active
+
+confidence: Confirmed
+
+version: 5
+
+refs:
+
+- code: DES-06
+  rel: constrains
+- code: DES-02
+  rel: constrains
+- code: RISK-02
+  rel: relates
+superseded_by:
+
+owner: architecture-team
+
+review_by: '2026-09-01'
+
+created_at: '2026-03-05T13:06:56.192012'
+
+updated_at: '2026-03-05T22:52:27.897378'
+

--- a/.lattice/facts/RISK-07.yaml
+++ b/.lattice/facts/RISK-07.yaml
@@ -20,8 +20,10 @@ status: Active
 confidence: Confirmed
 version: 3
 refs:
-- RISK-02
-- DES-02
+- code: RISK-02
+  rel: relates
+- code: DES-02
+  rel: constrains
 superseded_by:
 owner: architecture-team
 review_by: '2026-09-01'

--- a/.lattice/facts/RISK-08.yaml
+++ b/.lattice/facts/RISK-08.yaml
@@ -16,10 +16,14 @@ status: Active
 confidence: Confirmed
 version: 3
 refs:
-- ADR-14
-- RISK-03
-- RISK-04
-- DG-06
+- code: ADR-14
+  rel: constrains
+- code: RISK-03
+  rel: relates
+- code: RISK-04
+  rel: relates
+- code: DG-06
+  rel: relates
 superseded_by:
 owner: architecture-team
 review_by: '2026-06-01'

--- a/.lattice/facts/RISK-09.yaml
+++ b/.lattice/facts/RISK-09.yaml
@@ -15,8 +15,10 @@ status: Active
 confidence: Confirmed
 version: 3
 refs:
-- ADR-15
-- AUP-06
+- code: ADR-15
+  rel: constrains
+- code: AUP-06
+  rel: relates
 superseded_by:
 owner: architecture-team
 review_by: '2026-06-01'

--- a/.lattice/facts/RISK-10.yaml
+++ b/.lattice/facts/RISK-10.yaml
@@ -17,9 +17,12 @@ status: Active
 confidence: Confirmed
 version: 3
 refs:
-- DES-11
-- DES-12
-- ADR-17
+- code: DES-11
+  rel: constrains
+- code: DES-12
+  rel: constrains
+- code: ADR-17
+  rel: constrains
 superseded_by:
 owner: architecture-team
 review_by: '2026-09-01'

--- a/.lattice/facts/RISK-11.yaml
+++ b/.lattice/facts/RISK-11.yaml
@@ -18,10 +18,14 @@ status: Active
 confidence: Confirmed
 version: 3
 refs:
-- ADR-16
-- DES-06
-- DG-05
-- DG-01
+- code: ADR-16
+  rel: constrains
+- code: DES-06
+  rel: constrains
+- code: DG-05
+  rel: relates
+- code: DG-01
+  rel: relates
 superseded_by:
 owner: architecture-team
 review_by: '2026-09-01'

--- a/.lattice/facts/RUN-01.yaml
+++ b/.lattice/facts/RUN-01.yaml
@@ -14,8 +14,10 @@ status: Active
 confidence: Confirmed
 version: 1
 refs:
-- DG-01
-- PRD-01
+- code: DG-01
+  rel: validates
+- code: PRD-01
+  rel: implements
 superseded_by:
 owner: architecture-team
 review_by:

--- a/.lattice/facts/RUN-02.yaml
+++ b/.lattice/facts/RUN-02.yaml
@@ -14,8 +14,10 @@ status: Active
 confidence: Confirmed
 version: 1
 refs:
-- DES-01
-- MON-01
+- code: DES-01
+  rel: implements
+- code: MON-01
+  rel: depends_on
 superseded_by:
 owner: architecture-team
 review_by: '2026-09-01'

--- a/.lattice/facts/RUN-03.yaml
+++ b/.lattice/facts/RUN-03.yaml
@@ -15,8 +15,10 @@ status: Active
 confidence: Confirmed
 version: 1
 refs:
-- ADR-01
-- ADR-04
+- code: ADR-01
+  rel: implements
+- code: ADR-04
+  rel: implements
 superseded_by:
 owner: architecture-team
 review_by: '2026-09-01'

--- a/.lattice/facts/RUN-04.yaml
+++ b/.lattice/facts/RUN-04.yaml
@@ -15,8 +15,10 @@ status: Active
 confidence: Confirmed
 version: 2
 refs:
-- ADR-12
-- RUN-01
+- code: ADR-12
+  rel: implements
+- code: RUN-01
+  rel: depends_on
 superseded_by:
 owner: architecture-team
 review_by: '2026-09-01'

--- a/.lattice/facts/RUN-05.yaml
+++ b/.lattice/facts/RUN-05.yaml
@@ -15,9 +15,12 @@ status: Active
 confidence: Confirmed
 version: 2
 refs:
-- ADR-03
-- MC-02
-- SP-01
+- code: ADR-03
+  rel: implements
+- code: MC-02
+  rel: validates
+- code: SP-01
+  rel: depends_on
 superseded_by:
 owner: architecture-team
 review_by: '2026-09-01'

--- a/.lattice/facts/RUN-06.yaml
+++ b/.lattice/facts/RUN-06.yaml
@@ -17,9 +17,12 @@ status: Active
 confidence: Confirmed
 version: 3
 refs:
-- ADR-12
-- ADR-14
-- SP-07
+- code: ADR-12
+  rel: implements
+- code: ADR-14
+  rel: implements
+- code: SP-07
+  rel: depends_on
 superseded_by:
 owner: architecture-team
 review_by: '2026-06-01'

--- a/.lattice/facts/RUN-07.yaml
+++ b/.lattice/facts/RUN-07.yaml
@@ -1,30 +1,53 @@
-code: RUN-07
-layer: HOW
-type: Runbook Procedure
-fact: Backend migration procedure. Run lattice backend status to view the 
-  current backend type and fact count. Run lattice backend switch sqlite to 
-  migrate YAML to SQLite, or lattice backend switch yaml for the reverse. The 
-  switch command reads all facts from the source backend, writes them to the 
-  target, updates config.yaml with the new backend setting, and preserves the 
-  original data (YAML files or DB file) as backup. Migration is always explicit 
-  per RISK-06 — the system never auto-migrates. Verify the migration with 
-  lattice fact ls and lattice validate after switching.
-tags:
-- developer
-- incident-response
-- migration
-- sqlite
-- storage
-status: Active
-confidence: Confirmed
-version: 3
-refs:
-- ADR-16
-- RISK-06
-- DES-06
-superseded_by:
-owner: architecture-team
-review_by: '2026-09-01'
-created_at: '2026-03-05T23:55:55.524327'
-updated_at: '2026-03-07T11:23:18.967895'
-projects: []
+code: RUN-07
+
+layer: HOW
+
+type: Runbook Procedure
+
+fact: "Backend migration procedure. Run lattice backend status to view the\ncurrent
+  backend type and fact count. Run lattice backend switch sqlite to\nmigrate YAML
+  to SQLite, or lattice backend switch yaml for the reverse. The\nswitch command reads
+  all facts from the source backend, writes them to the\ntarget, updates config.yaml
+  with the new backend setting, and preserves the\noriginal data (YAML files or DB
+  file) as backup. Migration is always explicit\nper RISK-06 — the system never
+  auto-migrates. Verify the migration with\nlattice fact ls and lattice validate after
+  switching."
+
+tags:
+
+- developer
+
+- incident-response
+
+- migration
+
+- sqlite
+
+- storage
+
+status: Active
+
+confidence: Confirmed
+
+version: 3
+
+refs:
+
+- code: ADR-16
+  rel: implements
+- code: RISK-06
+  rel: validates
+- code: DES-06
+  rel: implements
+superseded_by:
+
+owner: architecture-team
+
+review_by: '2026-09-01'
+
+created_at: '2026-03-05T23:55:55.524327'
+
+updated_at: '2026-03-07T11:23:18.967895'
+
+projects: []
+

--- a/.lattice/facts/SP-01.yaml
+++ b/.lattice/facts/SP-01.yaml
@@ -13,9 +13,12 @@ status: Active
 confidence: Confirmed
 version: 1
 refs:
-- DES-01
-- ADR-04
-- MC-01
+- code: DES-01
+  rel: implements
+- code: ADR-04
+  rel: implements
+- code: MC-01
+  rel: validates
 superseded_by:
 owner: architecture-team
 review_by:

--- a/.lattice/facts/SP-02.yaml
+++ b/.lattice/facts/SP-02.yaml
@@ -15,8 +15,10 @@ status: Active
 confidence: Confirmed
 version: 1
 refs:
-- DES-02
-- RISK-02
+- code: DES-02
+  rel: implements
+- code: RISK-02
+  rel: mitigates
 superseded_by:
 owner: architecture-team
 review_by: '2026-09-01'

--- a/.lattice/facts/SP-03.yaml
+++ b/.lattice/facts/SP-03.yaml
@@ -15,8 +15,10 @@ status: Active
 confidence: Confirmed
 version: 1
 refs:
-- SP-02
-- DES-01
+- code: SP-02
+  rel: depends_on
+- code: DES-01
+  rel: implements
 superseded_by:
 owner: architecture-team
 review_by: '2026-09-01'

--- a/.lattice/facts/SP-04.yaml
+++ b/.lattice/facts/SP-04.yaml
@@ -15,9 +15,12 @@ status: Active
 confidence: Confirmed
 version: 2
 refs:
-- DES-04
-- ADR-10
-- SP-01
+- code: DES-04
+  rel: implements
+- code: ADR-10
+  rel: implements
+- code: SP-01
+  rel: depends_on
 superseded_by:
 owner: architecture-team
 review_by: '2026-09-01'

--- a/.lattice/facts/SP-05.yaml
+++ b/.lattice/facts/SP-05.yaml
@@ -15,8 +15,10 @@ status: Active
 confidence: Confirmed
 version: 2
 refs:
-- SP-04
-- DES-04
+- code: SP-04
+  rel: depends_on
+- code: DES-04
+  rel: implements
 superseded_by:
 owner: architecture-team
 review_by: '2026-09-01'

--- a/.lattice/facts/SP-06.yaml
+++ b/.lattice/facts/SP-06.yaml
@@ -15,8 +15,10 @@ status: Active
 confidence: Confirmed
 version: 2
 refs:
-- ADR-03
-- SP-01
+- code: ADR-03
+  rel: implements
+- code: SP-01
+  rel: depends_on
 superseded_by:
 owner: architecture-team
 review_by: '2026-09-01'

--- a/.lattice/facts/SP-07.yaml
+++ b/.lattice/facts/SP-07.yaml
@@ -17,9 +17,12 @@ status: Active
 confidence: Confirmed
 version: 3
 refs:
-- ADR-14
-- DG-06
-- RISK-08
+- code: ADR-14
+  rel: implements
+- code: DG-06
+  rel: validates
+- code: RISK-08
+  rel: mitigates
 superseded_by:
 owner: architecture-team
 review_by: '2026-06-01'

--- a/.lattice/facts/SP-08.yaml
+++ b/.lattice/facts/SP-08.yaml
@@ -15,9 +15,12 @@ status: Active
 confidence: Confirmed
 version: 3
 refs:
-- DES-09
-- DG-09
-- DG-02
+- code: DES-09
+  rel: implements
+- code: DG-09
+  rel: validates
+- code: DG-02
+  rel: validates
 superseded_by:
 owner: architecture-team
 review_by:

--- a/.lattice/facts/SP-09.yaml
+++ b/.lattice/facts/SP-09.yaml
@@ -16,9 +16,12 @@ status: Active
 confidence: Confirmed
 version: 3
 refs:
-- DES-10
-- DG-10
-- RISK-03
+- code: DES-10
+  rel: implements
+- code: DG-10
+  rel: validates
+- code: RISK-03
+  rel: mitigates
 superseded_by:
 owner: architecture-team
 review_by:

--- a/.lattice/facts/SP-10.yaml
+++ b/.lattice/facts/SP-10.yaml
@@ -19,10 +19,14 @@ status: Active
 confidence: Confirmed
 version: 3
 refs:
-- DES-11
-- DES-12
-- ADR-17
-- API-03
+- code: DES-11
+  rel: implements
+- code: DES-12
+  rel: implements
+- code: ADR-17
+  rel: implements
+- code: API-03
+  rel: depends_on
 superseded_by:
 owner: architecture-team
 review_by: '2026-09-01'

--- a/.lattice/facts/SP-11.yaml
+++ b/.lattice/facts/SP-11.yaml
@@ -16,9 +16,12 @@ status: Active
 confidence: Confirmed
 version: 3
 refs:
-- ADR-16
-- RISK-06
-- DES-06
+- code: ADR-16
+  rel: implements
+- code: RISK-06
+  rel: mitigates
+- code: DES-06
+  rel: implements
 superseded_by:
 owner: architecture-team
 review_by: '2026-09-01'

--- a/.lattice/history/changelog.jsonl
+++ b/.lattice/history/changelog.jsonl
@@ -161,3 +161,9 @@
 {"timestamp": "2026-03-07T11:23:18.969860", "action": "update", "code": "RUN-07", "reason": "Promoted to Active: Verified against implementation and promoted to Active"}
 {"timestamp": "2026-03-07T11:23:19.355546", "action": "update", "code": "SP-10", "reason": "Promoted to Active: Verified against implementation and promoted to Active"}
 {"timestamp": "2026-03-07T11:23:19.764809", "action": "update", "code": "SP-11", "reason": "Promoted to Active: Verified against implementation and promoted to Active"}
+{"timestamp": "2026-03-08T01:31:59.137144", "action": "update", "code": "AUP-07", "reason": "Updated priority loading rules to document 6-step context assembly pipeline with graph expansion (Layer 4)"}
+{"timestamp": "2026-03-08T01:45:44.747007", "action": "add", "code": "ADR-19", "reason": "Typed edges architecture decision (Layer 4)"}
+{"timestamp": "2026-03-08T01:45:44.747007", "action": "add", "code": "DES-13", "reason": "Context graph expansion design (Layer 4)"}
+{"timestamp": "2026-03-08T01:45:44.747007", "action": "add", "code": "DG-14", "reason": "Edge type vocabulary and validation rules (Layer 4)"}
+{"timestamp": "2026-03-08T01:45:44.747007", "action": "update", "code": "DG-06", "reason": "Updated superseded lifecycle: supersedes edge replaces superseded_by field"}
+{"timestamp": "2026-03-08T01:45:44.747007", "action": "update", "code": "DG-08", "reason": "Documented FactRef format for import overwrite path"}

--- a/.lattice/roles/architecture.yaml
+++ b/.lattice/roles/architecture.yaml
@@ -15,3 +15,9 @@ query:
   - api
   max_facts: 30
   extra: []
+  graph_depth: 1
+  edge_priority:
+  - constrains
+  - contradicts
+  - drives
+  - mitigates

--- a/.lattice/roles/deploy.yaml
+++ b/.lattice/roles/deploy.yaml
@@ -13,3 +13,9 @@ query:
   - ops-team
   max_facts: 15
   extra: []
+  graph_depth: 1
+  edge_priority:
+  - constrains
+  - contradicts
+  - drives
+  - mitigates

--- a/.lattice/roles/implementation.yaml
+++ b/.lattice/roles/implementation.yaml
@@ -14,3 +14,9 @@ query:
   - rate-limiting
   max_facts: 25
   extra: []
+  graph_depth: 1
+  edge_priority:
+  - constrains
+  - contradicts
+  - drives
+  - mitigates

--- a/.lattice/roles/planning.yaml
+++ b/.lattice/roles/planning.yaml
@@ -1,5 +1,5 @@
 name: Planning Agent
-description: Product Strategist — scopes work, defines acceptance criteria
+description: Product Strategist ï¿½ scopes work, defines acceptance criteria
 query:
   layers:
   - WHY
@@ -15,3 +15,9 @@ query:
   - layer: GUARDRAILS
     types:
     - Acceptable Use Policy Rule
+  graph_depth: 1
+  edge_priority:
+  - constrains
+  - contradicts
+  - drives
+  - mitigates

--- a/.lattice/roles/qa.yaml
+++ b/.lattice/roles/qa.yaml
@@ -14,3 +14,9 @@ query:
   - monitoring
   max_facts: 20
   extra: []
+  graph_depth: 1
+  edge_priority:
+  - constrains
+  - contradicts
+  - drives
+  - mitigates

--- a/seed/example_facts.yaml
+++ b/seed/example_facts.yaml
@@ -10,7 +10,10 @@
   status: Active
   confidence: Confirmed
   owner: architecture-team
-  refs: [DES-01, RISK-03, API-01]
+  refs:
+    - {code: DES-01, rel: drives}
+    - {code: RISK-03, rel: mitigates}
+    - {code: API-01, rel: drives}
 
 - code: ADR-03
   layer: WHY
@@ -23,7 +26,10 @@
   status: Active
   confidence: Confirmed
   owner: architecture-team
-  refs: [PRD-01, RISK-07, MC-01]
+  refs:
+    - {code: PRD-01, rel: relates}
+    - {code: RISK-07, rel: mitigates}
+    - {code: MC-01, rel: mitigates}
 
 - code: PRD-01
   layer: WHY
@@ -36,7 +42,10 @@
   status: Active
   confidence: Confirmed
   owner: product-team
-  refs: [ADR-01, MON-01, RISK-05]
+  refs:
+    - {code: ADR-01, rel: drives}
+    - {code: MON-01, rel: drives}
+    - {code: RISK-05, rel: mitigates}
 
 - code: DES-01
   layer: WHY
@@ -49,7 +58,10 @@
   status: Active
   confidence: Confirmed
   owner: architecture-team
-  refs: [ADR-01, API-01, RUN-01]
+  refs:
+    - {code: ADR-01, rel: relates}
+    - {code: API-01, rel: drives}
+    - {code: RUN-01, rel: drives}
 
 - code: MC-01
   layer: GUARDRAILS
@@ -61,7 +73,10 @@
   status: Active
   confidence: Confirmed
   owner: ml-team
-  refs: [ADR-03, ETH-01, RISK-02]
+  refs:
+    - {code: ADR-03, rel: constrains}
+    - {code: ETH-01, rel: relates}
+    - {code: RISK-02, rel: relates}
 
 - code: AUP-05
   layer: GUARDRAILS
@@ -74,7 +89,12 @@
   status: Active
   confidence: Confirmed
   owner: compliance-team
-  refs: [DG-01, DG-03, COMP-01, COMP-04, ETH-02]
+  refs:
+    - {code: DG-01, rel: relates}
+    - {code: DG-03, rel: relates}
+    - {code: COMP-01, rel: relates}
+    - {code: COMP-04, rel: relates}
+    - {code: ETH-02, rel: relates}
 
 - code: RISK-07
   layer: GUARDRAILS
@@ -88,7 +108,11 @@
   status: Active
   confidence: Confirmed
   owner: security-team
-  refs: [ADR-03, AUP-02, SP-03, MON-04]
+  refs:
+    - {code: ADR-03, rel: constrains}
+    - {code: AUP-02, rel: relates}
+    - {code: SP-03, rel: constrains}
+    - {code: MON-04, rel: constrains}
 
 - code: DG-01
   layer: GUARDRAILS
@@ -101,7 +125,10 @@
   status: Active
   confidence: Confirmed
   owner: security-team
-  refs: [AUP-05, COMP-04, SP-03]
+  refs:
+    - {code: AUP-05, rel: relates}
+    - {code: COMP-04, rel: relates}
+    - {code: SP-03, rel: constrains}
 
 - code: SP-01
   layer: HOW
@@ -114,7 +141,10 @@
   status: Active
   confidence: Confirmed
   owner: product-team
-  refs: [ETH-01, AUP-01, COMP-01]
+  refs:
+    - {code: ETH-01, rel: validates}
+    - {code: AUP-01, rel: validates}
+    - {code: COMP-01, rel: validates}
 
 - code: API-01
   layer: HOW
@@ -127,7 +157,10 @@
   status: Active
   confidence: Confirmed
   owner: backend-team
-  refs: [ADR-01, DES-01, MON-01]
+  refs:
+    - {code: ADR-01, rel: implements}
+    - {code: DES-01, rel: implements}
+    - {code: MON-01, rel: depends_on}
 
 - code: MON-01
   layer: HOW
@@ -140,7 +173,10 @@
   status: Active
   confidence: Confirmed
   owner: ops-team
-  refs: [PRD-01, RUN-01, RISK-05]
+  refs:
+    - {code: PRD-01, rel: implements}
+    - {code: RUN-01, rel: depends_on}
+    - {code: RISK-05, rel: validates}
 
 - code: RUN-01
   layer: HOW
@@ -154,4 +190,6 @@
   status: Active
   confidence: Confirmed
   owner: ops-team
-  refs: [MON-01, DES-01]
+  refs:
+    - {code: MON-01, rel: depends_on}
+    - {code: DES-01, rel: implements}

--- a/src/lattice_lens/cli/context_commands.py
+++ b/src/lattice_lens/cli/context_commands.py
@@ -25,6 +25,9 @@ def context(
         None, "--budget", help="Token budget (omit for unlimited)"
     ),
     project: Optional[str] = typer.Option(None, "--project", help="Filter facts by project scope"),
+    depth: Optional[int] = typer.Option(
+        None, "--depth", help="Graph traversal depth (0=off, 1=default, -1=unbounded)"
+    ),
     as_json: bool = typer.Option(False, "--json", help="Output assembled context as JSON"),
 ):
     """Assemble governed, token-budgeted facts for an agent role."""
@@ -47,7 +50,9 @@ def context(
         raise typer.Exit(1)
 
     template = templates[role]
-    result = assemble_context(store.index, role, template, budget=budget, project=project)
+    result = assemble_context(
+        store.index, role, template, budget=budget, project=project, graph_depth=depth
+    )
 
     if as_json:
         print(json.dumps(result.to_dict(), indent=2))
@@ -74,19 +79,23 @@ def context(
         return
 
     # Facts table
+    graph_set = set(result.graph_facts)
     table = Table(title="Assembled Facts")
     table.add_column("Code", style="bold")
     table.add_column("Layer")
     table.add_column("Type")
     table.add_column("Confidence")
+    table.add_column("Source")
     table.add_column("Tokens", justify="right")
 
     for fact in result.loaded_facts:
+        source = "graph" if fact.code in graph_set else "direct"
         table.add_row(
             fact.code,
             fact.layer.value,
             fact.type,
             fact.confidence.value,
+            source,
             str(estimate_fact_tokens(fact)),
         )
 

--- a/src/lattice_lens/cli/fact_commands.py
+++ b/src/lattice_lens/cli/fact_commands.py
@@ -124,9 +124,20 @@ def _add_interactive(store):
     # Confidence
     confidence_str = typer.prompt("Confidence", default="Confirmed")
 
-    # Refs
-    refs_input = typer.prompt("Refs (comma-separated codes, optional)", default="")
-    refs = [r.strip() for r in refs_input.split(",") if r.strip()]
+    # Refs — accepts "CODE" (defaults to relates) or "CODE:edge_type"
+    refs_input = typer.prompt(
+        "Refs (comma-separated, CODE or CODE:edge_type; optional)", default=""
+    )
+    refs: list[dict | str] = []
+    for r in refs_input.split(","):
+        r = r.strip()
+        if not r:
+            continue
+        if ":" in r:
+            ref_code, rel = r.split(":", 1)
+            refs.append({"code": ref_code.strip(), "rel": rel.strip()})
+        else:
+            refs.append(r)
 
     # Review by
     review_by_str = typer.prompt("Review by (YYYY-MM-DD, optional)", default="")
@@ -194,7 +205,7 @@ def fact_get(
         f"[bold]Version:[/bold] {fact.version}\n"
         f"[bold]Owner:[/bold] {fact.owner}\n"
         f"[bold]Tags:[/bold] {', '.join(fact.tags)}\n"
-        f"[bold]Refs:[/bold] {', '.join(fact.refs) if fact.refs else '(none)'}\n"
+        f"[bold]Refs:[/bold] {', '.join(f'{r.code} ({r.rel.value})' for r in fact.refs) if fact.refs else '(none)'}\n"
         f"[bold]Projects:[/bold] {projects_display}\n"
         f"[bold]Review by:[/bold] {fact.review_by or '(not set)'}\n"
         f"[bold]Created:[/bold] {fact.created_at}\n"

--- a/src/lattice_lens/cli/graph_commands.py
+++ b/src/lattice_lens/cli/graph_commands.py
@@ -73,7 +73,15 @@ def graph_impact(
         direct_branch = tree.add("[bold]Directly affected[/bold]")
         for c in result.directly_affected:
             f = index.get(c)
-            label = f"[cyan]{c}[/cyan] — {f.type}" if f else f"[dim]{c}[/dim] (not found)"
+            if f:
+                # Show how this fact references the source
+                edges = index.edges_to(code)
+                edge_label = ""
+                if c in edges:
+                    edge_label = f" [{edges[c].value}]"
+                label = f"[cyan]{c}[/cyan]{edge_label} — {f.type}"
+            else:
+                label = f"[dim]{c}[/dim] (not found)"
             direct_branch.add(label)
     else:
         tree.add("[dim]No directly affected facts[/dim]")

--- a/src/lattice_lens/cli/upgrade_command.py
+++ b/src/lattice_lens/cli/upgrade_command.py
@@ -6,7 +6,7 @@ from rich.console import Console
 from ruamel.yaml import YAML
 
 from lattice_lens.cli.helpers import require_local_lattice
-from lattice_lens.config import CONFIG_FILE, LATTICE_VERSION, ROLES_DIR
+from lattice_lens.config import CONFIG_FILE, FACTS_DIR, LATTICE_VERSION, ROLES_DIR
 
 console = Console()
 err_console = Console(stderr=True)
@@ -140,11 +140,92 @@ def _migrate_to_0_4_0(store) -> int:
     return 1
 
 
+def _migrate_to_0_7_0(store) -> int:
+    """Convert plain string refs to typed FactRef format using edge inference."""
+    from lattice_lens.services.edge_inference import infer_edge_type
+
+    facts_dir = store.root / FACTS_DIR
+    if not facts_dir.exists():
+        return 0
+
+    migrated = 0
+    for path in sorted(facts_dir.glob("*.yaml")):
+        try:
+            with open(path) as f:
+                data = yaml_rw.load(f)
+        except Exception:
+            continue
+
+        if data is None or "refs" not in data:
+            continue
+
+        refs = data["refs"]
+        if not refs or not isinstance(refs, list):
+            continue
+
+        # Check if already typed (list of dicts)
+        if all(isinstance(r, dict) for r in refs):
+            continue
+
+        source_code = data.get("code", "")
+        new_refs = []
+        for ref in refs:
+            if isinstance(ref, str):
+                edge_type = infer_edge_type(source_code, ref)
+                new_refs.append({"code": ref, "rel": edge_type.value})
+            elif isinstance(ref, dict):
+                new_refs.append(ref)
+            else:
+                new_refs.append({"code": str(ref), "rel": "relates"})
+
+        data["refs"] = new_refs
+        with open(path, "w") as f:
+            yaml_rw.dump(data, f)
+        console.print(f"  [green]Typed refs[/green] {path.name}")
+        migrated += 1
+
+    # Add graph_depth and edge_priority to role templates
+    roles_dir = store.root / ROLES_DIR
+    if roles_dir.exists():
+        for path in sorted(roles_dir.glob("*.yaml")):
+            try:
+                with open(path) as f:
+                    data = yaml_rw.load(f)
+            except Exception:
+                continue
+
+            if data is None or "query" not in data:
+                continue
+
+            query = data["query"]
+            changed = False
+            if "graph_depth" not in query:
+                query["graph_depth"] = 1
+                changed = True
+            if "edge_priority" not in query:
+                query["edge_priority"] = [
+                    "constrains",
+                    "contradicts",
+                    "drives",
+                    "mitigates",
+                ]
+                changed = True
+
+            if changed:
+                with open(path, "w") as f:
+                    yaml_rw.dump(data, f)
+                console.print(f"  [green]Updated role[/green] {path.name}")
+                migrated += 1
+
+    return migrated
+
+
 # Ordered list of migrations. Add new entries at the bottom for future phases.
 MIGRATIONS: list[tuple[str, str, callable]] = [
     ("0.2.0", "Nested query format for role templates", _migrate_to_0_2_0),
     ("0.3.0", "Type registry and canonical type names in role templates", _migrate_to_0_3_0),
     ("0.4.0", "Enriched type registry with descriptions", _migrate_to_0_4_0),
+    ("0.7.0", "Typed edges and graph expansion for context assembly", _migrate_to_0_7_0),
 ]
 
 

--- a/src/lattice_lens/cli/validate_command.py
+++ b/src/lattice_lens/cli/validate_command.py
@@ -111,9 +111,9 @@ def reindex():
             tag_index.setdefault(tag, []).append(f.code)
         layer_groups.setdefault(f.layer.value, []).append(f.code)
         if f.refs:
-            refs_forward[f.code] = f.refs
+            refs_forward[f.code] = f.ref_codes
         for ref in f.refs:
-            refs_reverse.setdefault(ref, []).append(f.code)
+            refs_reverse.setdefault(ref.code, []).append(f.code)
         by_status[f.status.value] = by_status.get(f.status.value, 0) + 1
         by_layer[f.layer.value] = by_layer.get(f.layer.value, 0) + 1
 

--- a/src/lattice_lens/config.py
+++ b/src/lattice_lens/config.py
@@ -22,7 +22,7 @@ LENS_FILE = ".lens"
 # "0.3.0" = Phase 5 (type registry, canonical types in role templates)
 # "0.4.0" = Phase 5 (enriched type registry with descriptions)
 # "0.5.0" = Phase 6 (reconciliation engine, SQLite backend)
-LATTICE_VERSION = "0.6.0"
+LATTICE_VERSION = "0.7.0"
 
 LAYER_PREFIXES: dict[str, list[str]] = {
     "WHY": ["ADR", "PRD", "ETH", "DES"],

--- a/src/lattice_lens/mcp/tools.py
+++ b/src/lattice_lens/mcp/tools.py
@@ -87,7 +87,7 @@ def tool_context_assemble(
                 "fact": f.fact,
                 "tags": f.tags,
                 "confidence": f.confidence.value,
-                "refs": f.refs,
+                "refs": [{"code": r.code, "rel": r.rel.value} for r in f.refs],
             }
             for f in result.loaded_facts
         ],

--- a/src/lattice_lens/models.py
+++ b/src/lattice_lens/models.py
@@ -30,6 +30,27 @@ class FactConfidence(str, enum.Enum):
     ASSUMED = "Assumed"
 
 
+class EdgeType(str, enum.Enum):
+    """Typed relationship between two facts."""
+
+    DRIVES = "drives"
+    CONSTRAINS = "constrains"
+    MITIGATES = "mitigates"
+    CONTRADICTS = "contradicts"
+    IMPLEMENTS = "implements"
+    SUPERSEDES = "supersedes"
+    VALIDATES = "validates"
+    DEPENDS_ON = "depends_on"
+    RELATES = "relates"
+
+
+class FactRef(BaseModel):
+    """A typed reference from one fact to another."""
+
+    code: str = Field(..., pattern=r"^[A-Z]+-\d+$")
+    rel: EdgeType = EdgeType.RELATES
+
+
 class Fact(BaseModel):
     """Core fact model. One YAML file per fact."""
 
@@ -41,13 +62,34 @@ class Fact(BaseModel):
     status: FactStatus = FactStatus.DRAFT
     confidence: FactConfidence = FactConfidence.CONFIRMED
     version: int = Field(default=1, ge=1)
-    refs: list[str] = Field(default_factory=list)
+    refs: list[FactRef] = Field(default_factory=list)
     superseded_by: str | None = None
     owner: str = Field(..., min_length=1, max_length=100)
     review_by: date | None = None
     created_at: datetime = Field(default_factory=datetime.now)
     updated_at: datetime = Field(default_factory=datetime.now)
     projects: list[str] = Field(default_factory=list)
+
+    @field_validator("refs", mode="before")
+    @classmethod
+    def normalize_refs(cls, v: list) -> list[FactRef]:
+        """Accept list[str], list[dict], or list[FactRef]. Strings become relates edges."""
+        result = []
+        for item in v:
+            if isinstance(item, str):
+                result.append(FactRef(code=item))
+            elif isinstance(item, dict):
+                result.append(FactRef(**item))
+            elif isinstance(item, FactRef):
+                result.append(item)
+            else:
+                raise ValueError(f"Invalid ref: {item}")
+        return result
+
+    @property
+    def ref_codes(self) -> list[str]:
+        """Return just the ref target codes (backward-compat convenience)."""
+        return [r.code for r in self.refs]
 
     @field_validator("projects")
     @classmethod

--- a/src/lattice_lens/services/context_service.py
+++ b/src/lattice_lens/services/context_service.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
-from lattice_lens.models import Fact, FactConfidence, FactStatus
+from lattice_lens.models import EdgeType, Fact, FactConfidence, FactStatus
 from lattice_lens.services.fact_service import is_stale
 from lattice_lens.services.graph_service import _get_query, _role_matches_fact
 from lattice_lens.services.project_service import fact_matches_project
@@ -34,7 +34,8 @@ def estimate_fact_tokens(fact: Fact) -> int:
         f"Tags: {', '.join(fact.tags)}",
     ]
     if fact.refs:
-        parts.append(f"Refs: {', '.join(fact.refs)}")
+        ref_strs = [f"{r.code}({r.rel.value})" for r in fact.refs]
+        parts.append(f"Edges: {', '.join(ref_strs)}")
     parts.append(fact.fact)
     return estimate_tokens("\n".join(parts))
 
@@ -54,6 +55,15 @@ def _tag_match_score(fact: Fact, role_tags: list[str]) -> int:
     return len(set(fact.tags) & set(role_tags))
 
 
+def _confidence_tier(fact: Fact) -> int:
+    """Return 0 for Confirmed (highest priority), 1 for Provisional/Assumed."""
+    if is_stale(fact):
+        return 1  # Stale facts downgraded to Provisional tier per DG-06
+    if fact.confidence == FactConfidence.CONFIRMED:
+        return 0
+    return 1  # Provisional, Assumed, etc.
+
+
 @dataclass
 class ContextResult:
     """Result of a context assembly for an agent role."""
@@ -64,6 +74,7 @@ class ContextResult:
     total_tokens: int = 0
     budget: int | None = None
     budget_exhausted: bool = False
+    graph_facts: list[str] = field(default_factory=list)
 
     def render_text(self) -> str:
         """Render assembled context as text for agent prompts."""
@@ -75,8 +86,10 @@ class ContextResult:
             lines.append(f"# Token budget: {self.budget}")
         lines.append("")
 
+        graph_set = set(self.graph_facts)
         for fact in self.loaded_facts:
-            lines.append(f"## [{fact.code} v{fact.version}] {fact.type}")
+            source = "graph" if fact.code in graph_set else "direct"
+            lines.append(f"## [{fact.code} v{fact.version}] {fact.type} ({source})")
             lines.append(
                 f"Layer: {fact.layer.value} | "
                 f"Status: {fact.status.value} | "
@@ -84,7 +97,8 @@ class ContextResult:
             )
             lines.append(f"Tags: {', '.join(fact.tags)}")
             if fact.refs:
-                lines.append(f"Refs: {', '.join(fact.refs)}")
+                edge_strs = [f"{r.rel.value}\u2192{r.code}" for r in fact.refs]
+                lines.append(f"Edges: {', '.join(edge_strs)}")
             lines.append("")
             lines.append(fact.fact)
             lines.append("")
@@ -100,6 +114,7 @@ class ContextResult:
 
     def to_dict(self) -> dict:
         """Serialize to dict for JSON output."""
+        graph_set = set(self.graph_facts)
         return {
             "role": self.role,
             "facts_loaded": len(self.loaded_facts),
@@ -115,13 +130,15 @@ class ContextResult:
                     "status": f.status.value,
                     "confidence": f.confidence.value,
                     "tags": f.tags,
-                    "refs": f.refs,
+                    "refs": [{"code": r.code, "rel": r.rel.value} for r in f.refs],
                     "fact": f.fact,
                     "tokens": estimate_fact_tokens(f),
+                    "source": "graph" if f.code in graph_set else "direct",
                 }
                 for f in self.loaded_facts
             ],
             "ref_pointers": self.ref_pointers,
+            "graph_facts": self.graph_facts,
         }
 
 
@@ -131,68 +148,109 @@ def assemble_context(
     role_template: dict,
     budget: int | None = None,
     project: str | None = None,
+    graph_depth: int | None = None,
 ) -> ContextResult:
     """Assemble facts for a role, respecting lifecycle and token budget.
 
-    Priority loading per AUP-07:
-    1. Confirmed facts first (Active with Confirmed confidence)
-    2. Provisional facts if budget remains (Under Review, or Active with Provisional)
-    3. Never Draft, Deprecated, or Superseded
+    6-step pipeline:
+    1. Project filter (narrow)
+    2. Role filter — layer/type match (narrow)
+    3. Tag filter/score (narrow — used for sorting, not exclusion)
+    4. Graph expansion (widen — only if candidates < max_facts and depth != 0)
+    5. Confidence sort with source_type tiebreaker
+    6. Take top N (max_facts then token budget)
 
-    Within each confidence tier, sort by tag match score (descending).
+    Priority loading per AUP-07:
+    - Confirmed facts first (Active with Confirmed confidence)
+    - Provisional facts if budget remains
+    - Never Draft, Deprecated, or Superseded
+    - Direct matches rank above graph-pulled within same confidence tier
     """
     query = _get_query(role_template)
     role_tags = query.get("tags", [])
     max_facts = query.get("max_facts")
 
-    # Collect all facts that match the role query
-    matched: list[Fact] = []
+    # Resolve graph_depth: CLI param overrides template value
+    effective_depth = graph_depth
+    if effective_depth is None:
+        effective_depth = query.get("graph_depth", 0)
+
+    # Parse edge priority from template
+    edge_priority_raw = query.get("edge_priority")
+    edge_priority: list[EdgeType] | None = None
+    if edge_priority_raw:
+        edge_priority = []
+        for ep in edge_priority_raw:
+            try:
+                edge_priority.append(EdgeType(ep))
+            except ValueError:
+                pass  # Skip unknown edge types
+
+    # Steps 1-2: Project filter + Role filter
+    direct_matched: list[Fact] = []
     for fact in index.all_facts():
         if fact.status in _EXCLUDED_STATUSES:
             continue
         if project and not fact_matches_project(fact.projects, project):
             continue
         if _role_matches_fact(role_template, fact.layer.value, fact.type):
-            matched.append(fact)
+            direct_matched.append(fact)
 
-    # Split into priority tiers.
-    # DG-06: stale facts (past review_by) are downgraded to Provisional tier
-    # regardless of their stored confidence. This is a runtime-only downgrade —
-    # the YAML file is not modified.
-    confirmed: list[Fact] = []
-    provisional: list[Fact] = []
+    direct_codes = {f.code for f in direct_matched}
 
-    for fact in matched:
-        if is_stale(fact):
-            # Review Expired — downgrade to Provisional tier per DG-06
-            provisional.append(fact)
-        elif fact.confidence == FactConfidence.CONFIRMED:
-            confirmed.append(fact)
-        elif fact.confidence == FactConfidence.PROVISIONAL:
-            provisional.append(fact)
-        else:
-            # Assumed confidence — treat like Provisional
-            provisional.append(fact)
+    # Step 4: Graph expansion — only if we have room and depth is enabled
+    graph_codes: set[str] = set()
+    graph_facts_list: list[Fact] = []
+    need_expansion = (
+        effective_depth != 0
+        and (max_facts is None or len(direct_matched) < max_facts)
+        and direct_codes  # need seeds for BFS
+    )
 
-    # Sort each tier by tag match score (descending), then code for stability
+    if need_expansion:
+        neighborhood = index.neighborhood(
+            seeds=direct_codes,
+            max_depth=abs(effective_depth) if effective_depth != -1 else -1,
+            edge_types=edge_priority,
+            excluded_statuses=_EXCLUDED_STATUSES,
+        )
+        for code, _distance in neighborhood.items():
+            if code in direct_codes:
+                continue  # Already a direct match
+            fact = index.get(code)
+            if fact is None:
+                continue
+            if fact.status in _EXCLUDED_STATUSES:
+                continue
+            if project and not fact_matches_project(fact.projects, project):
+                continue
+            graph_codes.add(code)
+            graph_facts_list.append(fact)
+
+    # Step 5: Unified sort — (confidence_tier, source_type, -tag_score, code)
+    # source_type: 0=direct, 1=graph-pulled
+    all_candidates = direct_matched + graph_facts_list
+
     def sort_key(f: Fact) -> tuple:
-        return (-_tag_match_score(f, role_tags), f.code)
+        tier = _confidence_tier(f)
+        source = 0 if f.code in direct_codes else 1
+        tag_score = _tag_match_score(f, role_tags)
+        return (tier, source, -tag_score, f.code)
 
-    confirmed.sort(key=sort_key)
-    provisional.sort(key=sort_key)
+    all_candidates.sort(key=sort_key)
 
-    # Priority loading: Confirmed first, then Provisional
-    ordered = confirmed + provisional
+    # Track all candidates before truncation for ref pointers
+    all_pool_codes = {f.code for f in all_candidates}
 
-    # Apply max_facts limit from role template
+    # Step 6: Apply max_facts limit
     if max_facts is not None:
-        ordered = ordered[:max_facts]
+        all_candidates = all_candidates[:max_facts]
 
-    # Load facts within budget
+    # Load facts within token budget
     result = ContextResult(role=role_name, budget=budget)
     loaded_codes: set[str] = set()
 
-    for fact in ordered:
+    for fact in all_candidates:
         tokens = estimate_fact_tokens(fact)
         if budget is not None and result.total_tokens + tokens > budget:
             result.budget_exhausted = True
@@ -200,23 +258,23 @@ def assemble_context(
         result.loaded_facts.append(fact)
         result.total_tokens += tokens
         loaded_codes.add(fact.code)
+        if fact.code in graph_codes:
+            result.graph_facts.append(fact.code)
 
     # Build REFS pointers for facts that exist but weren't loaded.
-    # Include: facts matching the role that were cut by budget/max_facts,
-    # plus any refs from loaded facts that point to unloaded facts.
-    all_matched_codes = {f.code for f in matched}
-    not_loaded_from_match = all_matched_codes - loaded_codes
+    # Includes facts cut by max_facts or budget from the full candidate pool.
+    not_loaded = all_pool_codes - loaded_codes
 
     # Also include refs from loaded facts that point outside the loaded set
     refs_outside: set[str] = set()
     for fact in result.loaded_facts:
         for ref in fact.refs:
-            if ref not in loaded_codes:
-                ref_fact = index.get(ref)
+            if ref.code not in loaded_codes:
+                ref_fact = index.get(ref.code)
                 if ref_fact and ref_fact.status not in _EXCLUDED_STATUSES:
-                    refs_outside.add(ref)
+                    refs_outside.add(ref.code)
 
-    all_pointers = sorted(not_loaded_from_match | refs_outside)
+    all_pointers = sorted(not_loaded | refs_outside)
     for code in all_pointers:
         ptr_fact = index.get(code)
         if ptr_fact:

--- a/src/lattice_lens/services/edge_inference.py
+++ b/src/lattice_lens/services/edge_inference.py
@@ -1,0 +1,93 @@
+"""Edge type inference from code prefix pairs.
+
+Used during migration (0.6.0 → 0.7.0) to convert untyped string refs
+to typed FactRef objects with inferred edge types.
+"""
+
+from __future__ import annotations
+
+from lattice_lens.config import LAYER_PREFIXES
+from lattice_lens.models import EdgeType
+
+# Prefix-pair heuristics: (source_prefix, target_prefix) -> EdgeType
+_PREFIX_PAIR_MAP: dict[tuple[str, str], EdgeType] = {
+    # PRD drives ADR
+    ("PRD", "ADR"): EdgeType.DRIVES,
+    ("ADR", "DES"): EdgeType.DRIVES,
+    ("ADR", "SP"): EdgeType.DRIVES,
+    ("ADR", "API"): EdgeType.DRIVES,
+    ("PRD", "DES"): EdgeType.DRIVES,
+    # ADR mitigates RISK
+    ("ADR", "RISK"): EdgeType.MITIGATES,
+    ("DES", "RISK"): EdgeType.MITIGATES,
+    ("SP", "RISK"): EdgeType.MITIGATES,
+    # MON validates RISK
+    ("MON", "RISK"): EdgeType.VALIDATES,
+    ("MON", "AUP"): EdgeType.VALIDATES,
+    ("MON", "DG"): EdgeType.VALIDATES,
+    # RISK constrains ADR/DES
+    ("RISK", "ADR"): EdgeType.CONSTRAINS,
+    ("RISK", "DES"): EdgeType.CONSTRAINS,
+    ("AUP", "SP"): EdgeType.CONSTRAINS,
+    ("AUP", "API"): EdgeType.CONSTRAINS,
+    ("DG", "SP"): EdgeType.CONSTRAINS,
+    ("COMP", "SP"): EdgeType.CONSTRAINS,
+    # SP/API/RUN implements DES/ADR
+    ("SP", "DES"): EdgeType.IMPLEMENTS,
+    ("API", "DES"): EdgeType.IMPLEMENTS,
+    ("RUN", "DES"): EdgeType.IMPLEMENTS,
+    ("SP", "ADR"): EdgeType.IMPLEMENTS,
+    ("API", "ADR"): EdgeType.IMPLEMENTS,
+    # DES depends_on DES
+    ("DES", "DES"): EdgeType.DEPENDS_ON,
+    ("SP", "SP"): EdgeType.DEPENDS_ON,
+    ("API", "API"): EdgeType.DEPENDS_ON,
+    ("RUN", "RUN"): EdgeType.DEPENDS_ON,
+    ("RUN", "MON"): EdgeType.DEPENDS_ON,
+}
+
+# Build reverse map: prefix -> layer
+_PREFIX_TO_LAYER: dict[str, str] = {}
+for _layer, _prefixes in LAYER_PREFIXES.items():
+    for _prefix in _prefixes:
+        _PREFIX_TO_LAYER[_prefix] = _layer
+
+# Layer-pair fallbacks: (source_layer, target_layer) -> EdgeType
+_LAYER_PAIR_MAP: dict[tuple[str, str], EdgeType] = {
+    ("WHY", "HOW"): EdgeType.DRIVES,
+    ("HOW", "WHY"): EdgeType.IMPLEMENTS,
+    ("GUARDRAILS", "WHY"): EdgeType.CONSTRAINS,
+    ("GUARDRAILS", "HOW"): EdgeType.CONSTRAINS,
+    ("HOW", "HOW"): EdgeType.DEPENDS_ON,
+    ("WHY", "WHY"): EdgeType.RELATES,
+    ("HOW", "GUARDRAILS"): EdgeType.VALIDATES,
+    ("WHY", "GUARDRAILS"): EdgeType.MITIGATES,
+    ("GUARDRAILS", "GUARDRAILS"): EdgeType.RELATES,
+}
+
+
+def infer_edge_type(source_code: str, target_code: str) -> EdgeType:
+    """Infer edge type from source and target code prefixes.
+
+    Priority:
+    1. Exact prefix-pair match (e.g., PRD→ADR = drives)
+    2. Layer-pair fallback (e.g., WHY→HOW = drives)
+    3. Default: relates
+    """
+    source_prefix = source_code.split("-")[0]
+    target_prefix = target_code.split("-")[0]
+
+    # Try exact prefix pair
+    edge = _PREFIX_PAIR_MAP.get((source_prefix, target_prefix))
+    if edge is not None:
+        return edge
+
+    # Try layer pair fallback
+    source_layer = _PREFIX_TO_LAYER.get(source_prefix)
+    target_layer = _PREFIX_TO_LAYER.get(target_prefix)
+    if source_layer and target_layer:
+        edge = _LAYER_PAIR_MAP.get((source_layer, target_layer))
+        if edge is not None:
+            return edge
+
+    return EdgeType.RELATES

--- a/src/lattice_lens/services/evaluate_service.py
+++ b/src/lattice_lens/services/evaluate_service.py
@@ -127,7 +127,7 @@ class EvaluationResult:
             for fact in self.guardrails:
                 lines.append(f"### [{fact.code}] {fact.type} ({fact.confidence.value})")
                 if fact.refs:
-                    lines.append(f"Refs: {', '.join(fact.refs)}")
+                    lines.append(f"Refs: {', '.join(fact.ref_codes)}")
                 lines.append("")
                 lines.append(fact.fact)
                 lines.append("")
@@ -196,7 +196,7 @@ class EvaluationResult:
                     "type": f.type,
                     "confidence": f.confidence.value,
                     "tags": f.tags,
-                    "refs": f.refs,
+                    "refs": [{"code": r.code, "rel": r.rel.value} for r in f.refs],
                     "fact": f.fact,
                 }
                 for f in self.guardrails

--- a/src/lattice_lens/services/extract_service.py
+++ b/src/lattice_lens/services/extract_service.py
@@ -32,7 +32,7 @@ Respond ONLY with a valid JSON array. Each object has these fields:
 - fact: The atomic fact as a complete, self-contained sentence or short paragraph
 - tags: Array of at least 2 lowercase hyphenated tags
 - confidence: "Confirmed" if explicitly stated in the document, "Provisional" if inferred, "Assumed" if your interpretation
-- refs: Array of codes this fact relates to (use codes you've assigned to other facts in this extraction)
+- refs: Array of references. Each ref can be a plain code string (defaults to "relates") or an object {"code": "ADR-01", "rel": "drives"}. Edge types: drives, constrains, mitigates, contradicts, implements, supersedes, validates, depends_on, relates
 - owner: Best guess at the responsible team based on content (e.g., "architecture-team", "security-team", "product-team")
 
 Do not include any preamble, explanation, or markdown formatting. Only valid JSON."""

--- a/src/lattice_lens/services/fact_service.py
+++ b/src/lattice_lens/services/fact_service.py
@@ -34,12 +34,16 @@ def infer_layer(prefix: str) -> str | None:
     return PREFIX_TO_LAYER.get(prefix)
 
 
-def check_refs(store: LatticeStore, refs: list[str]) -> list[str]:
-    """Return list of warning messages for refs pointing to non-existent codes."""
+def check_refs(store: LatticeStore, refs: list) -> list[str]:
+    """Return list of warning messages for refs pointing to non-existent codes.
+
+    Accepts list[str], list[FactRef], or mixed.
+    """
     warnings = []
     for ref in refs:
-        if not store.exists(ref):
-            warnings.append(f"Reference target '{ref}' does not exist (soft warning)")
+        code = ref.code if hasattr(ref, "code") else ref
+        if not store.exists(code):
+            warnings.append(f"Reference target '{code}' does not exist (soft warning)")
     return warnings
 
 

--- a/src/lattice_lens/services/graph_service.py
+++ b/src/lattice_lens/services/graph_service.py
@@ -158,17 +158,39 @@ def find_contradiction_candidates(
     index: FactIndex,
     min_shared_tags: int = 2,
 ) -> list[tuple[str, str, list[str]]]:
-    """Find pairs of Active facts that share tags but differ in layer or owner.
+    """Find pairs of Active facts that share tags but differ in layer or owner,
+    plus any pairs explicitly linked with a CONTRADICTS edge.
 
     These are CANDIDATES for human review, not confirmed contradictions.
     Returns list of (code_a, code_b, shared_tags) tuples.
     """
+    from lattice_lens.models import EdgeType
+
     active_facts = [f for f in index.all_facts() if f.status.value == "Active"]
+    seen_pairs: set[tuple[str, str]] = set()
     candidates = []
+
+    # Tag-based contradiction candidates
     for i, a in enumerate(active_facts):
         for b in active_facts[i + 1 :]:
             shared = sorted(set(a.tags) & set(b.tags))
             if len(shared) >= min_shared_tags:
                 if a.layer != b.layer or a.owner != b.owner:
-                    candidates.append((a.code, b.code, shared))
+                    pair = (min(a.code, b.code), max(a.code, b.code))
+                    if pair not in seen_pairs:
+                        seen_pairs.add(pair)
+                        candidates.append((a.code, b.code, shared))
+
+    # Explicit CONTRADICTS edges
+    for fact in active_facts:
+        edges = index.edges_from(fact.code, edge_types=[EdgeType.CONTRADICTS])
+        for target_code in edges:
+            target = index.get(target_code)
+            if target and target.status.value == "Active":
+                pair = (min(fact.code, target_code), max(fact.code, target_code))
+                if pair not in seen_pairs:
+                    seen_pairs.add(pair)
+                    shared = sorted(set(fact.tags) & set(target.tags))
+                    candidates.append((fact.code, target_code, shared))
+
     return candidates

--- a/src/lattice_lens/services/reconcile_service.py
+++ b/src/lattice_lens/services/reconcile_service.py
@@ -158,7 +158,7 @@ def render_reconciliation_prompt(
     if active_facts:
         for fact in active_facts:
             tags_str = ", ".join(fact.tags) if fact.tags else "none"
-            refs_str = ", ".join(fact.refs) if fact.refs else "none"
+            refs_str = ", ".join(fact.ref_codes) if fact.refs else "none"
             sections.append(
                 f"### [{fact.code}] {fact.type} ({fact.layer.value})\n"
                 f"Tags: {tags_str}\n"
@@ -219,7 +219,7 @@ def _build_llm_user_message(
     sections.append("## Active Governance Facts\n")
     for fact in active_facts:
         tags_str = ", ".join(fact.tags) if fact.tags else "none"
-        refs_str = ", ".join(fact.refs) if fact.refs else "none"
+        refs_str = ", ".join(fact.ref_codes) if fact.refs else "none"
         sections.append(
             f"### [{fact.code}] {fact.type} ({fact.layer.value})\n"
             f"Tags: {tags_str} | Refs: {refs_str} | "

--- a/src/lattice_lens/services/validate_service.py
+++ b/src/lattice_lens/services/validate_service.py
@@ -98,9 +98,7 @@ def validate_lattice(facts_dir: Path) -> ValidationResult:
         if fact.tags != sorted(fact.tags):
             result.add_warning(f"{path.name}: Tags are not sorted")
 
-        # Check superseded consistency
-        if fact.status.value == "Superseded" and not fact.superseded_by:
-            result.add_error(f"{path.name}: Superseded fact missing superseded_by")
+        # Superseded consistency is checked after all facts are loaded (see below)
 
         # Check staleness
         if fact.review_by and fact.review_by < today:
@@ -111,8 +109,28 @@ def validate_lattice(facts_dir: Path) -> ValidationResult:
     # Check ref integrity (soft warnings)
     for fact in all_facts:
         for ref in fact.refs:
-            if ref not in all_codes:
-                result.add_warning(f"{fact.code}: Reference target '{ref}' does not exist")
+            if ref.code not in all_codes:
+                result.add_warning(f"{fact.code}: Reference target '{ref.code}' does not exist")
+
+    # Check superseded consistency — requires all facts to be loaded
+    # Superseded facts need either superseded_by field OR an inbound supersedes edge
+    from lattice_lens.models import EdgeType
+
+    supersedes_targets: set[str] = set()
+    for fact in all_facts:
+        for ref in fact.refs:
+            if ref.rel == EdgeType.SUPERSEDES:
+                supersedes_targets.add(ref.code)
+
+    for fact in all_facts:
+        if fact.status.value == "Superseded":
+            has_field = bool(fact.superseded_by)
+            has_edge = fact.code in supersedes_targets
+            if not has_field and not has_edge:
+                result.add_error(
+                    f"{fact.code}: Superseded fact has neither "
+                    "superseded_by field nor inbound supersedes edge"
+                )
 
     # Check type canonicality (RISK-03 mitigation)
     from lattice_lens.services.type_service import canonical_type_for_prefix

--- a/src/lattice_lens/store/index.py
+++ b/src/lattice_lens/store/index.py
@@ -3,13 +3,27 @@
 from __future__ import annotations
 
 import sys
+from collections import deque
 from pathlib import Path
 
 from ruamel.yaml import YAML
 
-from lattice_lens.models import Fact
+from lattice_lens.models import EdgeType, Fact, FactStatus
 
 yaml = YAML()
+
+# Inverse labels for display (e.g. "drives" → "driven_by")
+INVERSE_LABELS: dict[EdgeType, str] = {
+    EdgeType.DRIVES: "driven_by",
+    EdgeType.CONSTRAINS: "constrained_by",
+    EdgeType.MITIGATES: "mitigated_by",
+    EdgeType.CONTRADICTS: "contradicted_by",
+    EdgeType.IMPLEMENTS: "implemented_by",
+    EdgeType.SUPERSEDES: "superseded_by",
+    EdgeType.VALIDATES: "validated_by",
+    EdgeType.DEPENDS_ON: "depended_on_by",
+    EdgeType.RELATES: "related_to",
+}
 
 
 class FactIndex:
@@ -21,6 +35,8 @@ class FactIndex:
         self._by_layer: dict[str, set[str]] = {}  # layer -> {codes}
         self._refs_forward: dict[str, set[str]] = {}  # code -> {referenced codes}
         self._refs_reverse: dict[str, set[str]] = {}  # code -> {codes that reference this}
+        self._edges_forward: dict[str, dict[str, EdgeType]] = {}  # code -> {target: edge_type}
+        self._edges_reverse: dict[str, dict[str, EdgeType]] = {}  # code -> {source: edge_type}
         self._by_project: dict[str, set[str]] = {}  # project -> {codes}
         self._global_codes: set[str] = set()  # codes with empty projects (global)
 
@@ -47,10 +63,14 @@ class FactIndex:
             self._by_tag.setdefault(tag, set()).add(fact.code)
         # Layer index
         self._by_layer.setdefault(fact.layer.value, set()).add(fact.code)
-        # Ref graph
-        self._refs_forward[fact.code] = set(fact.refs)
+        # Ref graph (untyped — backward compat)
+        self._refs_forward[fact.code] = set(r.code for r in fact.refs)
         for ref in fact.refs:
-            self._refs_reverse.setdefault(ref, set()).add(fact.code)
+            self._refs_reverse.setdefault(ref.code, set()).add(fact.code)
+        # Typed edge graph
+        self._edges_forward[fact.code] = {r.code: r.rel for r in fact.refs}
+        for ref in fact.refs:
+            self._edges_reverse.setdefault(ref.code, {})[fact.code] = ref.rel
         # Project index
         if fact.projects:
             for project in fact.projects:
@@ -75,6 +95,80 @@ class FactIndex:
 
     def refs_to(self, code: str) -> set[str]:
         return self._refs_reverse.get(code, set())
+
+    def edges_from(
+        self, code: str, edge_types: list[EdgeType] | None = None
+    ) -> dict[str, EdgeType]:
+        """Return {target_code: edge_type} for outgoing edges from code.
+
+        If edge_types is provided, only return edges matching those types.
+        """
+        edges = self._edges_forward.get(code, {})
+        if edge_types is None:
+            return dict(edges)
+        return {k: v for k, v in edges.items() if v in edge_types}
+
+    def edges_to(self, code: str, edge_types: list[EdgeType] | None = None) -> dict[str, EdgeType]:
+        """Return {source_code: edge_type} for incoming edges to code.
+
+        If edge_types is provided, only return edges matching those types.
+        """
+        edges = self._edges_reverse.get(code, {})
+        if edge_types is None:
+            return dict(edges)
+        return {k: v for k, v in edges.items() if v in edge_types}
+
+    def neighborhood(
+        self,
+        seeds: set[str],
+        max_depth: int = 1,
+        edge_types: list[EdgeType] | None = None,
+        excluded_statuses: set[FactStatus] | None = None,
+    ) -> dict[str, int]:
+        """BFS from seed codes, returning {code: hop_distance}.
+
+        Traverses both forward and reverse edges. Seeds are at distance 0.
+        max_depth=-1 means unbounded. Skips facts with excluded statuses.
+        """
+        if excluded_statuses is None:
+            excluded_statuses = set()
+
+        result: dict[str, int] = {}
+        for seed in seeds:
+            result[seed] = 0
+
+        queue: deque[tuple[str, int]] = deque()
+        for seed in seeds:
+            queue.append((seed, 0))
+
+        visited = set(seeds)
+
+        while queue:
+            code, depth = queue.popleft()
+            if max_depth != -1 and depth >= max_depth:
+                continue
+
+            # Collect neighbors from both directions
+            neighbors: dict[str, EdgeType] = {}
+            neighbors.update(self.edges_from(code, edge_types))
+            neighbors.update(self.edges_to(code, edge_types))
+
+            for neighbor_code in neighbors:
+                if neighbor_code in visited:
+                    continue
+                visited.add(neighbor_code)
+
+                # Check if the neighbor fact exists and is not excluded
+                neighbor_fact = self.get(neighbor_code)
+                if neighbor_fact is None:
+                    continue
+                if neighbor_fact.status in excluded_statuses:
+                    continue
+
+                result[neighbor_code] = depth + 1
+                queue.append((neighbor_code, depth + 1))
+
+        return result
 
     def codes_by_project(self, project: str) -> set[str]:
         return self._by_project.get(project, set())

--- a/src/lattice_lens/store/sqlite_store.py
+++ b/src/lattice_lens/store/sqlite_store.py
@@ -40,6 +40,7 @@ CREATE TABLE IF NOT EXISTS fact_tags (
 CREATE TABLE IF NOT EXISTS fact_refs (
     source_code TEXT NOT NULL REFERENCES facts(code) ON DELETE CASCADE,
     target_code TEXT NOT NULL,
+    rel_type    TEXT NOT NULL DEFAULT 'relates',
     PRIMARY KEY (source_code, target_code)
 );
 
@@ -90,9 +91,20 @@ class SqliteStore:
         return self._conn
 
     def _ensure_schema(self):
-        """Create tables if they don't exist."""
+        """Create tables if they don't exist, and run migrations."""
         self.conn.executescript(_SCHEMA)
         self.conn.commit()
+        self._migrate_schema()
+
+    def _migrate_schema(self):
+        """Run schema migrations for existing databases."""
+        # Migration: add rel_type column to fact_refs if missing
+        cols = {row[1] for row in self.conn.execute("PRAGMA table_info(fact_refs)").fetchall()}
+        if "rel_type" not in cols:
+            self.conn.execute(
+                "ALTER TABLE fact_refs ADD COLUMN rel_type TEXT NOT NULL DEFAULT 'relates'"
+            )
+            self.conn.commit()
 
     @property
     def index(self) -> FactIndex:
@@ -195,8 +207,8 @@ class SqliteStore:
                 )
             for ref in fact.refs:
                 self.conn.execute(
-                    "INSERT INTO fact_refs (source_code, target_code) VALUES (?, ?)",
-                    (fact.code, ref),
+                    "INSERT INTO fact_refs (source_code, target_code, rel_type) VALUES (?, ?, ?)",
+                    (fact.code, ref.code, ref.rel.value),
                 )
             for project in fact.projects:
                 self.conn.execute(
@@ -256,8 +268,8 @@ class SqliteStore:
             self.conn.execute("DELETE FROM fact_refs WHERE source_code = ?", (code,))
             for ref in updated.refs:
                 self.conn.execute(
-                    "INSERT INTO fact_refs (source_code, target_code) VALUES (?, ?)",
-                    (code, ref),
+                    "INSERT INTO fact_refs (source_code, target_code, rel_type) VALUES (?, ?, ?)",
+                    (code, ref.code, ref.rel.value),
                 )
             # Replace projects
             self.conn.execute("DELETE FROM fact_projects WHERE code = ?", (code,))
@@ -323,12 +335,12 @@ class SqliteStore:
         ).fetchall()
         tags = [r["tag"] for r in tag_rows]
 
-        # Fetch refs
+        # Fetch refs (typed)
         ref_rows = self.conn.execute(
-            "SELECT target_code FROM fact_refs WHERE source_code = ? ORDER BY target_code",
+            "SELECT target_code, rel_type FROM fact_refs WHERE source_code = ? ORDER BY target_code",
             (code,),
         ).fetchall()
-        refs = [r["target_code"] for r in ref_rows]
+        refs = [{"code": r["target_code"], "rel": r["rel_type"]} for r in ref_rows]
 
         # Fetch projects
         project_rows = self.conn.execute(

--- a/tests/test_context_service.py
+++ b/tests/test_context_service.py
@@ -480,3 +480,404 @@ class TestStaleDowngrade:
 
         result = assemble_context(index, "test", template)
         assert len(result.loaded_facts) == 1  # Still loaded, just in lower tier
+
+
+class TestGraphExpansion:
+    """Tests for graph expansion (Phase 3 — Layer 4)."""
+
+    def _make_role_template(self, **query_overrides):
+        query = {
+            "layers": ["WHY"],
+            "types": ["Architecture Decision Record"],
+            "tags": ["architecture"],
+            "max_facts": 50,
+            "extra": [],
+        }
+        query.update(query_overrides)
+        return {"name": "Test Agent", "query": query}
+
+    def test_graph_depth_0_no_expansion(self):
+        """depth=0 disables graph expansion."""
+        adr = make_fact(
+            code="ADR-01",
+            status=FactStatus.ACTIVE,
+            tags=["architecture", "test"],
+            refs=[{"code": "RISK-01", "rel": "mitigates"}],
+        )
+        risk = make_fact(
+            code="RISK-01",
+            layer=FactLayer.GUARDRAILS,
+            type="Risk Assessment Finding",
+            status=FactStatus.ACTIVE,
+            tags=["risk", "test"],
+        )
+        index = _build_index([adr, risk])
+        template = self._make_role_template()
+
+        result = assemble_context(index, "test", template, graph_depth=0)
+        codes = [f.code for f in result.loaded_facts]
+        assert "ADR-01" in codes
+        assert "RISK-01" not in codes
+        assert result.graph_facts == []
+
+    def test_graph_depth_1_expands_neighbors(self):
+        """depth=1 pulls in directly connected facts."""
+        adr = make_fact(
+            code="ADR-01",
+            status=FactStatus.ACTIVE,
+            tags=["architecture", "test"],
+            refs=[{"code": "RISK-01", "rel": "mitigates"}],
+        )
+        risk = make_fact(
+            code="RISK-01",
+            layer=FactLayer.GUARDRAILS,
+            type="Risk Assessment Finding",
+            status=FactStatus.ACTIVE,
+            tags=["risk", "test"],
+        )
+        index = _build_index([adr, risk])
+        template = self._make_role_template()
+
+        result = assemble_context(index, "test", template, graph_depth=1)
+        codes = [f.code for f in result.loaded_facts]
+        assert "ADR-01" in codes
+        assert "RISK-01" in codes
+        assert "RISK-01" in result.graph_facts
+
+    def test_graph_depth_cli_overrides_template(self):
+        """CLI graph_depth parameter overrides template graph_depth."""
+        adr = make_fact(
+            code="ADR-01",
+            status=FactStatus.ACTIVE,
+            tags=["architecture", "test"],
+            refs=["RISK-01"],
+        )
+        risk = make_fact(
+            code="RISK-01",
+            layer=FactLayer.GUARDRAILS,
+            type="Risk Assessment Finding",
+            status=FactStatus.ACTIVE,
+            tags=["risk", "test"],
+        )
+        index = _build_index([adr, risk])
+        # Template says depth=1, but CLI says depth=0
+        template = self._make_role_template(graph_depth=1)
+
+        result = assemble_context(index, "test", template, graph_depth=0)
+        codes = [f.code for f in result.loaded_facts]
+        assert "RISK-01" not in codes  # CLI override wins
+
+    def test_template_graph_depth_used_when_no_cli(self):
+        """Template graph_depth is used when CLI doesn't specify depth."""
+        adr = make_fact(
+            code="ADR-01",
+            status=FactStatus.ACTIVE,
+            tags=["architecture", "test"],
+            refs=["RISK-01"],
+        )
+        risk = make_fact(
+            code="RISK-01",
+            layer=FactLayer.GUARDRAILS,
+            type="Risk Assessment Finding",
+            status=FactStatus.ACTIVE,
+            tags=["risk", "test"],
+        )
+        index = _build_index([adr, risk])
+        template = self._make_role_template(graph_depth=1)
+
+        result = assemble_context(index, "test", template)  # No graph_depth CLI arg
+        codes = [f.code for f in result.loaded_facts]
+        assert "RISK-01" in codes  # Template depth=1 kicks in
+
+    def test_direct_before_graph_in_sort(self):
+        """Direct matches rank above graph-pulled within same confidence tier."""
+        # ADR-01 is a direct match, RISK-01 is graph-pulled
+        adr = make_fact(
+            code="ADR-01",
+            status=FactStatus.ACTIVE,
+            confidence=FactConfidence.CONFIRMED,
+            tags=["architecture", "test"],
+            refs=[{"code": "RISK-01", "rel": "mitigates"}],
+        )
+        risk = make_fact(
+            code="RISK-01",
+            layer=FactLayer.GUARDRAILS,
+            type="Risk Assessment Finding",
+            status=FactStatus.ACTIVE,
+            confidence=FactConfidence.CONFIRMED,
+            tags=["risk", "test"],
+        )
+        index = _build_index([adr, risk])
+        template = self._make_role_template()
+
+        result = assemble_context(index, "test", template, graph_depth=1)
+        assert len(result.loaded_facts) == 2
+        # Direct match first, graph-pulled second (same confidence tier)
+        assert result.loaded_facts[0].code == "ADR-01"
+        assert result.loaded_facts[1].code == "RISK-01"
+
+    def test_confidence_beats_source_type(self):
+        """Confidence tier takes priority over source type."""
+        # ADR-01 (direct, Provisional), RISK-01 (graph, Confirmed)
+        adr = make_fact(
+            code="ADR-01",
+            status=FactStatus.ACTIVE,
+            confidence=FactConfidence.PROVISIONAL,
+            tags=["architecture", "test"],
+            refs=[{"code": "RISK-01", "rel": "mitigates"}],
+        )
+        risk = make_fact(
+            code="RISK-01",
+            layer=FactLayer.GUARDRAILS,
+            type="Risk Assessment Finding",
+            status=FactStatus.ACTIVE,
+            confidence=FactConfidence.CONFIRMED,
+            tags=["risk", "test"],
+        )
+        index = _build_index([adr, risk])
+        template = self._make_role_template()
+
+        result = assemble_context(index, "test", template, graph_depth=1)
+        # RISK-01 (Confirmed, graph) should come before ADR-01 (Provisional, direct)
+        assert result.loaded_facts[0].code == "RISK-01"
+        assert result.loaded_facts[1].code == "ADR-01"
+
+    def test_budget_enforced_after_expansion(self):
+        """Token budget is enforced on the expanded candidate set."""
+        adr = make_fact(
+            code="ADR-01",
+            status=FactStatus.ACTIVE,
+            tags=["architecture", "test"],
+            refs=["RISK-01"],
+        )
+        risk = make_fact(
+            code="RISK-01",
+            layer=FactLayer.GUARDRAILS,
+            type="Risk Assessment Finding",
+            status=FactStatus.ACTIVE,
+            tags=["risk", "test"],
+        )
+        index = _build_index([adr, risk])
+        template = self._make_role_template()
+
+        # Budget so small only one fact fits
+        result = assemble_context(index, "test", template, budget=50, graph_depth=1)
+        assert len(result.loaded_facts) == 1
+        assert result.budget_exhausted is True
+
+    def test_no_expansion_when_max_facts_met(self):
+        """Graph expansion doesn't run if direct matches already meet max_facts."""
+        facts = [
+            make_fact(
+                code=f"ADR-{i:02d}",
+                status=FactStatus.ACTIVE,
+                tags=["architecture", "test"],
+                refs=["RISK-01"],
+            )
+            for i in range(1, 4)
+        ]
+        risk = make_fact(
+            code="RISK-01",
+            layer=FactLayer.GUARDRAILS,
+            type="Risk Assessment Finding",
+            status=FactStatus.ACTIVE,
+            tags=["risk", "test"],
+        )
+        index = _build_index(facts + [risk])
+        template = self._make_role_template(max_facts=3)
+
+        result = assemble_context(index, "test", template, graph_depth=1)
+        codes = [f.code for f in result.loaded_facts]
+        assert "RISK-01" not in codes  # No expansion because 3 directs already fill max_facts
+
+    def test_expansion_fills_remaining_slots(self):
+        """Graph expansion runs when direct matches < max_facts."""
+        adr = make_fact(
+            code="ADR-01",
+            status=FactStatus.ACTIVE,
+            tags=["architecture", "test"],
+            refs=["RISK-01"],
+        )
+        risk = make_fact(
+            code="RISK-01",
+            layer=FactLayer.GUARDRAILS,
+            type="Risk Assessment Finding",
+            status=FactStatus.ACTIVE,
+            tags=["risk", "test"],
+        )
+        index = _build_index([adr, risk])
+        template = self._make_role_template(max_facts=5)
+
+        result = assemble_context(index, "test", template, graph_depth=1)
+        codes = [f.code for f in result.loaded_facts]
+        assert "RISK-01" in codes  # Expansion fills remaining slots
+
+    def test_edge_priority_filter(self):
+        """edge_priority in template limits which edges are traversed."""
+        adr = make_fact(
+            code="ADR-01",
+            status=FactStatus.ACTIVE,
+            tags=["architecture", "test"],
+            refs=[
+                {"code": "RISK-01", "rel": "mitigates"},
+                {"code": "DES-01", "rel": "relates"},
+            ],
+        )
+        risk = make_fact(
+            code="RISK-01",
+            layer=FactLayer.GUARDRAILS,
+            type="Risk Assessment Finding",
+            status=FactStatus.ACTIVE,
+            tags=["risk", "test"],
+        )
+        des = make_fact(
+            code="DES-01",
+            layer=FactLayer.WHY,
+            type="Design Proposal Decision",
+            status=FactStatus.ACTIVE,
+            tags=["design", "test"],
+        )
+        index = _build_index([adr, risk, des])
+        # Only follow "mitigates" edges
+        template = self._make_role_template(graph_depth=1, edge_priority=["mitigates"])
+
+        result = assemble_context(index, "test", template)
+        codes = [f.code for f in result.loaded_facts]
+        assert "RISK-01" in codes  # mitigates edge followed
+        # DES-01 may or may not be in codes (it's a direct match via layer/type)
+        # But it should NOT be in graph_facts
+        assert "DES-01" not in result.graph_facts
+
+    def test_graph_facts_tracking(self):
+        """graph_facts list accurately tracks which facts came from expansion."""
+        adr = make_fact(
+            code="ADR-01",
+            status=FactStatus.ACTIVE,
+            tags=["architecture", "test"],
+            refs=["RISK-01", "SP-01"],
+        )
+        risk = make_fact(
+            code="RISK-01",
+            layer=FactLayer.GUARDRAILS,
+            type="Risk Assessment Finding",
+            status=FactStatus.ACTIVE,
+            tags=["risk", "test"],
+        )
+        sp = make_fact(
+            code="SP-01",
+            layer=FactLayer.HOW,
+            type="System Prompt Rule",
+            status=FactStatus.ACTIVE,
+            tags=["system", "test"],
+        )
+        index = _build_index([adr, risk, sp])
+        template = self._make_role_template()
+
+        result = assemble_context(index, "test", template, graph_depth=1)
+        # ADR-01 is direct, RISK-01 and SP-01 are graph-pulled
+        assert "ADR-01" not in result.graph_facts
+        assert "RISK-01" in result.graph_facts
+        assert "SP-01" in result.graph_facts
+
+    def test_to_dict_includes_source(self):
+        """to_dict output includes 'source' field per fact."""
+        adr = make_fact(
+            code="ADR-01",
+            status=FactStatus.ACTIVE,
+            tags=["architecture", "test"],
+            refs=["RISK-01"],
+        )
+        risk = make_fact(
+            code="RISK-01",
+            layer=FactLayer.GUARDRAILS,
+            type="Risk Assessment Finding",
+            status=FactStatus.ACTIVE,
+            tags=["risk", "test"],
+        )
+        index = _build_index([adr, risk])
+        template = self._make_role_template()
+
+        result = assemble_context(index, "test", template, graph_depth=1)
+        d = result.to_dict()
+        fact_sources = {f["code"]: f["source"] for f in d["facts"]}
+        assert fact_sources["ADR-01"] == "direct"
+        assert fact_sources["RISK-01"] == "graph"
+
+    def test_render_text_shows_source(self):
+        """render_text includes (direct) or (graph) per fact."""
+        adr = make_fact(
+            code="ADR-01",
+            status=FactStatus.ACTIVE,
+            tags=["architecture", "test"],
+            refs=["RISK-01"],
+        )
+        risk = make_fact(
+            code="RISK-01",
+            layer=FactLayer.GUARDRAILS,
+            type="Risk Assessment Finding",
+            status=FactStatus.ACTIVE,
+            tags=["risk", "test"],
+        )
+        index = _build_index([adr, risk])
+        template = self._make_role_template()
+
+        result = assemble_context(index, "test", template, graph_depth=1)
+        text = result.render_text()
+        assert "(direct)" in text
+        assert "(graph)" in text
+
+    def test_excluded_statuses_not_expanded(self):
+        """Graph expansion skips Draft/Deprecated/Superseded facts."""
+        adr = make_fact(
+            code="ADR-01",
+            status=FactStatus.ACTIVE,
+            tags=["architecture", "test"],
+            refs=["RISK-01"],
+        )
+        risk = make_fact(
+            code="RISK-01",
+            layer=FactLayer.GUARDRAILS,
+            type="Risk Assessment Finding",
+            status=FactStatus.DEPRECATED,
+            tags=["risk", "test"],
+        )
+        index = _build_index([adr, risk])
+        template = self._make_role_template()
+
+        result = assemble_context(index, "test", template, graph_depth=1)
+        codes = [f.code for f in result.loaded_facts]
+        assert "RISK-01" not in codes
+
+    def test_unbounded_depth(self):
+        """depth=-1 traverses entire connected component."""
+        adr = make_fact(
+            code="ADR-01",
+            status=FactStatus.ACTIVE,
+            tags=["architecture", "test"],
+            refs=["DES-01"],
+        )
+        des = make_fact(
+            code="DES-01",
+            layer=FactLayer.WHY,
+            type="Design Proposal Decision",
+            status=FactStatus.ACTIVE,
+            tags=["design", "test"],
+            refs=["SP-01"],
+        )
+        sp = make_fact(
+            code="SP-01",
+            layer=FactLayer.HOW,
+            type="System Prompt Rule",
+            status=FactStatus.ACTIVE,
+            tags=["system", "test"],
+        )
+        index = _build_index([adr, des, sp])
+        template = self._make_role_template()
+
+        result = assemble_context(index, "test", template, graph_depth=-1)
+        codes = [f.code for f in result.loaded_facts]
+        # DES-01 is a direct match (WHY/Design Proposal Decision matches template)
+        # SP-01 is graph-pulled
+        assert "ADR-01" in codes
+        assert "DES-01" in codes
+        assert "SP-01" in codes

--- a/tests/test_edge_inference.py
+++ b/tests/test_edge_inference.py
@@ -1,0 +1,69 @@
+"""Tests for edge type inference from code prefix pairs."""
+
+from __future__ import annotations
+
+from lattice_lens.models import EdgeType
+from lattice_lens.services.edge_inference import infer_edge_type
+
+
+class TestPrefixPairInference:
+    """Exact prefix-pair matches."""
+
+    def test_prd_to_adr_drives(self):
+        assert infer_edge_type("PRD-01", "ADR-03") == EdgeType.DRIVES
+
+    def test_adr_to_des_drives(self):
+        assert infer_edge_type("ADR-01", "DES-01") == EdgeType.DRIVES
+
+    def test_adr_to_risk_mitigates(self):
+        assert infer_edge_type("ADR-01", "RISK-03") == EdgeType.MITIGATES
+
+    def test_mon_to_risk_validates(self):
+        assert infer_edge_type("MON-01", "RISK-05") == EdgeType.VALIDATES
+
+    def test_risk_to_adr_constrains(self):
+        assert infer_edge_type("RISK-07", "ADR-01") == EdgeType.CONSTRAINS
+
+    def test_sp_to_des_implements(self):
+        assert infer_edge_type("SP-01", "DES-01") == EdgeType.IMPLEMENTS
+
+    def test_des_to_des_depends_on(self):
+        assert infer_edge_type("DES-01", "DES-02") == EdgeType.DEPENDS_ON
+
+    def test_aup_to_sp_constrains(self):
+        assert infer_edge_type("AUP-05", "SP-01") == EdgeType.CONSTRAINS
+
+
+class TestLayerPairFallback:
+    """When no prefix-pair match, fall back to layer pairs."""
+
+    def test_eth_to_sp_drives(self):
+        """ETH→SP: WHY→HOW = drives (no prefix pair for ETH→SP)."""
+        assert infer_edge_type("ETH-01", "SP-01") == EdgeType.DRIVES
+
+    def test_run_to_prd_implements(self):
+        """RUN→PRD: HOW→WHY = implements."""
+        assert infer_edge_type("RUN-01", "PRD-01") == EdgeType.IMPLEMENTS
+
+    def test_mc_to_adr_constrains(self):
+        """MC→ADR: GUARDRAILS→WHY = constrains."""
+        assert infer_edge_type("MC-01", "ADR-01") == EdgeType.CONSTRAINS
+
+
+class TestDefaultRelates:
+    """Unknown prefix combinations default to relates."""
+
+    def test_unknown_prefix(self):
+        assert infer_edge_type("FOO-01", "BAR-01") == EdgeType.RELATES
+
+    def test_same_unknown(self):
+        assert infer_edge_type("FOO-01", "FOO-02") == EdgeType.RELATES
+
+
+class TestIdempotent:
+    """Inference is deterministic and stable."""
+
+    def test_same_input_same_output(self):
+        result1 = infer_edge_type("ADR-01", "RISK-03")
+        result2 = infer_edge_type("ADR-01", "RISK-03")
+        assert result1 == result2

--- a/tests/test_exchange.py
+++ b/tests/test_exchange.py
@@ -188,7 +188,7 @@ class TestRoundTrip:
             tuple(sorted(item.get("tags", []))),
             item["status"],
             item["confidence"],
-            tuple(sorted(item.get("refs", []))),
+            tuple(sorted(r["code"] if isinstance(r, dict) else r for r in item.get("refs", []))),
             item["owner"],
         )
 

--- a/tests/test_git_commands.py
+++ b/tests/test_git_commands.py
@@ -188,7 +188,7 @@ class TestUpgradeCommand:
         # Verify version stamped in config
         with open(lattice_dir / "config.yaml") as f:
             config = yaml_rw.load(f)
-        assert config["version"] == "0.6.0"
+        assert config["version"] == "0.7.0"
 
     def test_upgrade_noop_new_format(self, cli_dir: Path):
         """lattice upgrade on v0.2.0 lattice is a no-op."""

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+from lattice_lens.models import EdgeType, FactStatus
+from lattice_lens.store.index import INVERSE_LABELS
 from lattice_lens.store.yaml_store import YamlFileStore
+from tests.conftest import make_fact
 
 
 class TestFactIndex:
@@ -48,3 +51,213 @@ class TestFactIndex:
         assert len(index.all_facts()) == 0
         assert index.get("ADR-01") is None
         assert index.codes_by_tag("test") == set()
+
+
+class TestTypedEdges:
+    """Tests for typed edge indexing (Phase 2)."""
+
+    def test_edges_from_typed_seed(self, seeded_store: YamlFileStore):
+        """Seed data uses typed refs — ADR-01 drives DES-01."""
+        index = seeded_store.index
+        edges = index.edges_from("ADR-01")
+        assert "DES-01" in edges
+        assert edges["DES-01"] == EdgeType.DRIVES
+
+    def test_edges_from_typed(self, yaml_store: YamlFileStore):
+        """Facts with typed refs produce correct edge types."""
+        fact = make_fact(
+            code="ADR-01",
+            refs=[{"code": "DES-01", "rel": "drives"}, {"code": "RISK-01", "rel": "mitigates"}],
+        )
+        yaml_store.create(fact)
+        yaml_store.invalidate_index()
+        index = yaml_store.index
+        edges = index.edges_from("ADR-01")
+        assert edges["DES-01"] == EdgeType.DRIVES
+        assert edges["RISK-01"] == EdgeType.MITIGATES
+
+    def test_edges_to_reverse(self, yaml_store: YamlFileStore):
+        """Reverse edge index populated correctly."""
+        fact = make_fact(
+            code="ADR-01",
+            refs=[{"code": "DES-01", "rel": "drives"}],
+        )
+        yaml_store.create(fact)
+        yaml_store.invalidate_index()
+        index = yaml_store.index
+        edges = index.edges_to("DES-01")
+        assert "ADR-01" in edges
+        assert edges["ADR-01"] == EdgeType.DRIVES
+
+    def test_edges_from_filter(self, yaml_store: YamlFileStore):
+        """edge_types filter limits returned edges."""
+        fact = make_fact(
+            code="ADR-01",
+            refs=[
+                {"code": "DES-01", "rel": "drives"},
+                {"code": "RISK-01", "rel": "mitigates"},
+                {"code": "PRD-01", "rel": "relates"},
+            ],
+        )
+        yaml_store.create(fact)
+        yaml_store.invalidate_index()
+        index = yaml_store.index
+        edges = index.edges_from("ADR-01", edge_types=[EdgeType.DRIVES])
+        assert "DES-01" in edges
+        assert "RISK-01" not in edges
+        assert "PRD-01" not in edges
+
+    def test_edges_to_filter(self, yaml_store: YamlFileStore):
+        """edge_types filter on reverse edges."""
+        f1 = make_fact(code="ADR-01", refs=[{"code": "DES-01", "rel": "drives"}])
+        f2 = make_fact(code="ADR-02", refs=[{"code": "DES-01", "rel": "relates"}])
+        yaml_store.create(f1)
+        yaml_store.create(f2)
+        yaml_store.invalidate_index()
+        index = yaml_store.index
+        edges = index.edges_to("DES-01", edge_types=[EdgeType.DRIVES])
+        assert "ADR-01" in edges
+        assert "ADR-02" not in edges
+
+    def test_edges_from_empty(self, yaml_store: YamlFileStore):
+        """Fact with no refs returns empty edges."""
+        fact = make_fact(code="ADR-01")
+        yaml_store.create(fact)
+        yaml_store.invalidate_index()
+        index = yaml_store.index
+        assert index.edges_from("ADR-01") == {}
+
+    def test_edges_to_no_inbound(self, yaml_store: YamlFileStore):
+        """Fact with no inbound refs returns empty edges."""
+        fact = make_fact(code="ADR-01")
+        yaml_store.create(fact)
+        yaml_store.invalidate_index()
+        index = yaml_store.index
+        assert index.edges_to("ADR-01") == {}
+
+
+class TestInverseLabels:
+    def test_all_edge_types_have_inverse(self):
+        for edge_type in EdgeType:
+            assert edge_type in INVERSE_LABELS
+
+    def test_inverse_label_format(self):
+        assert INVERSE_LABELS[EdgeType.DRIVES] == "driven_by"
+        assert INVERSE_LABELS[EdgeType.SUPERSEDES] == "superseded_by"
+        assert INVERSE_LABELS[EdgeType.RELATES] == "related_to"
+
+
+class TestNeighborhood:
+    """Tests for BFS neighborhood traversal."""
+
+    def _build_index(self, yaml_store, facts):
+        """Helper to create facts and build index."""
+        for fact in facts:
+            yaml_store.create(fact)
+        yaml_store.invalidate_index()
+        return yaml_store.index
+
+    def test_depth_0_returns_seeds_only(self, yaml_store: YamlFileStore):
+        """Depth 0 means no expansion."""
+        f1 = make_fact(code="ADR-01", refs=["DES-01"])
+        f2 = make_fact(code="DES-01")
+        index = self._build_index(yaml_store, [f1, f2])
+        result = index.neighborhood({"ADR-01"}, max_depth=0)
+        assert result == {"ADR-01": 0}
+
+    def test_depth_1_finds_direct_neighbors(self, yaml_store: YamlFileStore):
+        """Depth 1 finds directly connected facts."""
+        f1 = make_fact(code="ADR-01", refs=["DES-01"])
+        f2 = make_fact(code="DES-01")
+        index = self._build_index(yaml_store, [f1, f2])
+        result = index.neighborhood({"ADR-01"}, max_depth=1)
+        assert result == {"ADR-01": 0, "DES-01": 1}
+
+    def test_depth_1_traverses_reverse(self, yaml_store: YamlFileStore):
+        """Depth 1 also follows reverse edges."""
+        f1 = make_fact(code="ADR-01", refs=["DES-01"])
+        f2 = make_fact(code="DES-01")
+        index = self._build_index(yaml_store, [f1, f2])
+        # Starting from DES-01, should find ADR-01 via reverse edge
+        result = index.neighborhood({"DES-01"}, max_depth=1)
+        assert result == {"DES-01": 0, "ADR-01": 1}
+
+    def test_depth_2_traverses_two_hops(self, yaml_store: YamlFileStore):
+        """Depth 2 follows chains: A → B → C."""
+        f1 = make_fact(code="ADR-01", refs=["DES-01"])
+        f2 = make_fact(code="DES-01", refs=["SP-01"])
+        f3 = make_fact(code="SP-01", layer="HOW", type="System Prompt Rule")
+        index = self._build_index(yaml_store, [f1, f2, f3])
+        result = index.neighborhood({"ADR-01"}, max_depth=2)
+        assert result == {"ADR-01": 0, "DES-01": 1, "SP-01": 2}
+
+    def test_depth_1_stops_at_one_hop(self, yaml_store: YamlFileStore):
+        """Depth 1 does not reach two-hop neighbors."""
+        f1 = make_fact(code="ADR-01", refs=["DES-01"])
+        f2 = make_fact(code="DES-01", refs=["SP-01"])
+        f3 = make_fact(code="SP-01", layer="HOW", type="System Prompt Rule")
+        index = self._build_index(yaml_store, [f1, f2, f3])
+        result = index.neighborhood({"ADR-01"}, max_depth=1)
+        assert "SP-01" not in result
+
+    def test_unbounded_depth(self, yaml_store: YamlFileStore):
+        """Depth -1 traverses entire connected component."""
+        f1 = make_fact(code="ADR-01", refs=["DES-01"])
+        f2 = make_fact(code="DES-01", refs=["SP-01"])
+        f3 = make_fact(code="SP-01", layer="HOW", type="System Prompt Rule")
+        index = self._build_index(yaml_store, [f1, f2, f3])
+        result = index.neighborhood({"ADR-01"}, max_depth=-1)
+        assert set(result.keys()) == {"ADR-01", "DES-01", "SP-01"}
+
+    def test_excluded_statuses_skipped(self, yaml_store: YamlFileStore):
+        """Deprecated facts are skipped during traversal."""
+        f1 = make_fact(code="ADR-01", refs=["DES-01"])
+        f2 = make_fact(code="DES-01", status=FactStatus.DEPRECATED)
+        index = self._build_index(yaml_store, [f1, f2])
+        result = index.neighborhood(
+            {"ADR-01"}, max_depth=1, excluded_statuses={FactStatus.DEPRECATED}
+        )
+        assert result == {"ADR-01": 0}
+        assert "DES-01" not in result
+
+    def test_edge_type_filter(self, yaml_store: YamlFileStore):
+        """edge_types filter limits which edges are traversed."""
+        f1 = make_fact(
+            code="ADR-01",
+            refs=[
+                {"code": "DES-01", "rel": "drives"},
+                {"code": "RISK-01", "rel": "relates"},
+            ],
+        )
+        f2 = make_fact(code="DES-01")
+        f3 = make_fact(code="RISK-01", layer="GUARDRAILS", type="Risk Assessment Finding")
+        index = self._build_index(yaml_store, [f1, f2, f3])
+        # Only follow "drives" edges
+        result = index.neighborhood({"ADR-01"}, max_depth=1, edge_types=[EdgeType.DRIVES])
+        assert "DES-01" in result
+        assert "RISK-01" not in result
+
+    def test_cycle_handling(self, yaml_store: YamlFileStore):
+        """Cycles don't cause infinite loops."""
+        f1 = make_fact(code="ADR-01", refs=["DES-01"])
+        f2 = make_fact(code="DES-01", refs=["ADR-01"])
+        index = self._build_index(yaml_store, [f1, f2])
+        result = index.neighborhood({"ADR-01"}, max_depth=-1)
+        assert set(result.keys()) == {"ADR-01", "DES-01"}
+
+    def test_multiple_seeds(self, yaml_store: YamlFileStore):
+        """Multiple seeds expand from all starting points."""
+        f1 = make_fact(code="ADR-01", refs=["DES-01"])
+        f2 = make_fact(code="DES-01")
+        f3 = make_fact(code="ADR-02", refs=["SP-01"])
+        f4 = make_fact(code="SP-01", layer="HOW", type="System Prompt Rule")
+        index = self._build_index(yaml_store, [f1, f2, f3, f4])
+        result = index.neighborhood({"ADR-01", "ADR-02"}, max_depth=1)
+        assert set(result.keys()) == {"ADR-01", "ADR-02", "DES-01", "SP-01"}
+
+    def test_nonexistent_ref_target_skipped(self, yaml_store: YamlFileStore):
+        """Refs pointing to non-existent facts are skipped gracefully."""
+        f1 = make_fact(code="ADR-01", refs=["MISSING-01"])
+        index = self._build_index(yaml_store, [f1])
+        result = index.neighborhood({"ADR-01"}, max_depth=1)
+        assert result == {"ADR-01": 0}

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 
-from lattice_lens.models import FactLayer, FactStatus
+from lattice_lens.models import EdgeType, FactLayer, FactRef, FactStatus
 from tests.conftest import make_fact
 
 
@@ -53,3 +53,55 @@ class TestFactCreation:
     def test_tag_special_chars_rejected(self):
         with pytest.raises(ValidationError):
             make_fact(tags=["good-tag", "bad tag!"])
+
+
+class TestEdgeTypes:
+    def test_edge_type_enum_values(self):
+        assert len(EdgeType) == 9
+        assert EdgeType.DRIVES == "drives"
+        assert EdgeType.RELATES == "relates"
+        assert EdgeType.SUPERSEDES == "supersedes"
+
+    def test_factref_from_code(self):
+        ref = FactRef(code="ADR-01")
+        assert ref.code == "ADR-01"
+        assert ref.rel == EdgeType.RELATES
+
+    def test_factref_with_edge_type(self):
+        ref = FactRef(code="ADR-01", rel=EdgeType.DRIVES)
+        assert ref.rel == EdgeType.DRIVES
+
+    def test_factref_invalid_code(self):
+        with pytest.raises(ValidationError):
+            FactRef(code="bad-code")
+
+    def test_refs_backward_compat_strings(self):
+        fact = make_fact(refs=["ADR-01", "DES-01"])
+        assert len(fact.refs) == 2
+        assert all(isinstance(r, FactRef) for r in fact.refs)
+        assert fact.refs[0].code == "ADR-01"
+        assert fact.refs[0].rel == EdgeType.RELATES
+
+    def test_refs_from_dicts(self):
+        fact = make_fact(refs=[{"code": "ADR-01", "rel": "drives"}])
+        assert fact.refs[0].code == "ADR-01"
+        assert fact.refs[0].rel == EdgeType.DRIVES
+
+    def test_refs_mixed_input(self):
+        fact = make_fact(refs=["ADR-01", {"code": "DES-01", "rel": "drives"}])
+        assert fact.refs[0].rel == EdgeType.RELATES
+        assert fact.refs[1].rel == EdgeType.DRIVES
+
+    def test_ref_codes_property(self):
+        fact = make_fact(refs=["ADR-01", "DES-01"])
+        assert fact.ref_codes == ["ADR-01", "DES-01"]
+
+    def test_refs_model_dump_json(self):
+        fact = make_fact(refs=[{"code": "ADR-01", "rel": "drives"}])
+        dumped = fact.model_dump(mode="json")
+        assert dumped["refs"] == [{"code": "ADR-01", "rel": "drives"}]
+
+    def test_refs_empty_default(self):
+        fact = make_fact()
+        assert fact.refs == []
+        assert fact.ref_codes == []

--- a/tests/test_sqlite_store.py
+++ b/tests/test_sqlite_store.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 
 from lattice_lens.config import FACTS_DIR, HISTORY_DIR, LATTICE_DIR, ROLES_DIR
-from lattice_lens.models import FactLayer, FactStatus
+from lattice_lens.models import EdgeType, FactLayer, FactStatus
 from lattice_lens.store.sqlite_store import SqliteStore
 from tests.conftest import make_fact
 
@@ -177,5 +177,41 @@ class TestSqliteStoreCRUD:
         fact = sqlite_store.get("ADR-01")
         assert "new-tag" in fact.tags
         assert "old-tag" not in fact.tags
-        assert "DES-02" in fact.refs
-        assert "DES-01" not in fact.refs
+        assert "DES-02" in fact.ref_codes
+        assert "DES-01" not in fact.ref_codes
+
+    def test_typed_refs_round_trip(self, sqlite_store: SqliteStore):
+        """Typed refs are stored and retrieved with correct edge types."""
+        sqlite_store.create(
+            make_fact(
+                code="ADR-01",
+                refs=[
+                    {"code": "DES-01", "rel": "drives"},
+                    {"code": "RISK-01", "rel": "mitigates"},
+                ],
+            )
+        )
+        fact = sqlite_store.get("ADR-01")
+        assert len(fact.refs) == 2
+        ref_map = {r.code: r.rel for r in fact.refs}
+        assert ref_map["DES-01"] == EdgeType.DRIVES
+        assert ref_map["RISK-01"] == EdgeType.MITIGATES
+
+    def test_typed_refs_update_round_trip(self, sqlite_store: SqliteStore):
+        """Typed refs survive update cycles."""
+        sqlite_store.create(make_fact(code="ADR-01", refs=[{"code": "DES-01", "rel": "drives"}]))
+        sqlite_store.update(
+            "ADR-01",
+            {"refs": [{"code": "RISK-01", "rel": "constrains"}]},
+            "change refs",
+        )
+        fact = sqlite_store.get("ADR-01")
+        assert len(fact.refs) == 1
+        assert fact.refs[0].code == "RISK-01"
+        assert fact.refs[0].rel == EdgeType.CONSTRAINS
+
+    def test_plain_string_refs_default_relates(self, sqlite_store: SqliteStore):
+        """Plain string refs default to 'relates' edge type in SQLite."""
+        sqlite_store.create(make_fact(code="ADR-01", refs=["DES-01"]))
+        fact = sqlite_store.get("ADR-01")
+        assert fact.refs[0].rel == EdgeType.RELATES


### PR DESCRIPTION
## Summary

- **9 typed edge types** for fact references (`drives`, `constrains`, `mitigates`, `contradicts`, `implements`, `supersedes`, `validates`, `depends_on`, `relates`) replacing untyped string refs with structured `FactRef` objects
- **BFS graph traversal** integrated into context assembly as a demand-driven expansion step (Step 4 of 6-step pipeline), configurable via `--depth` CLI flag and `graph_depth`/`edge_priority` in role templates
- **Schema version 0.7.0** with migration that infers edge types from prefix-pair heuristics and layer-pair fallbacks
- **Backward compatible** — plain string refs auto-coerce to `FactRef(code=s, rel=RELATES)` via Pydantic field validator

### Changes across 5 phases

| Phase | Scope | Key files |
|-------|-------|-----------|
| 1 | Core data model | `models.py` (EdgeType, FactRef, refs field, ref_codes property) |
| 2 | Index + storage | `store/index.py` (typed edges, BFS neighborhood), `sqlite_store.py` (rel_type column) |
| 3 | Context assembly | `context_service.py` (6-step pipeline, graph expansion, unified sort) |
| 4 | CLI/MCP/validation | `--depth` flag, edge types in display, structured MCP refs, supersedes validation |
| 5 | Migration + lattice | `edge_inference.py`, 0.7.0 migration, 90 facts migrated, 3 new + 3 updated lattice facts |

### Lattice facts
- **New:** ADR-19 (typed edges decision), DES-13 (graph expansion design), DG-14 (edge vocabulary rules)
- **Updated:** AUP-07 (6-step pipeline), DG-06 (supersedes edge lifecycle), DG-08 (FactRef import format)

## Test plan

- [x] 532 tests passing (`pytest -m "not integration"`)
- [x] Lint clean (`ruff check .`)
- [x] Format clean (`ruff format --check .`)
- [x] `lattice validate` passes on upgraded project lattice (93 facts)
- [ ] Verify `lattice context assemble architecture --depth 1` shows graph-pulled facts
- [ ] Verify `lattice fact get ADR-01` shows typed edges
- [ ] Verify `lattice graph impact ADR-03` shows edge type labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)