### PR TITLE
Add PyPI publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,64 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install build tools
+        run: pip install build
+      - name: Build package
+        run: python -m build
+      - name: Check distribution
+        run: |
+          pip install twine
+          twine check dist/*
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  test-pypi:
+    name: Publish to TestPyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment: test-pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+      - name: Verify install from TestPyPI
+        run: |
+          sleep 15
+          pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ lattice-lens==${{ github.event.release.tag_name#v }}
+
+  pypi:
+    name: Publish to PyPI
+    needs: test-pypi
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,22 @@
 name = "lattice-lens"
 version = "1.0.0"
 description = "Knowledge governance layer for AI agent systems"
-license = {text = "MIT"}
+license = "MIT"
 requires-python = ">=3.11"
+readme = "README.md"
+authors = [{name = "HVallad"}]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Software Development :: Libraries",
+    "Topic :: Software Development :: Quality Assurance",
+    "Typing :: Typed",
+]
 dependencies = [
     "typer>=0.12.0",
     "rich>=13.0.0",
@@ -12,11 +26,18 @@ dependencies = [
     "ruamel.yaml>=0.18.0",
 ]
 
+[project.urls]
+Homepage = "https://github.com/HVallad/LatticeLens"
+Repository = "https://github.com/HVallad/LatticeLens"
+Changelog = "https://github.com/HVallad/LatticeLens/blob/main/CHANGELOG.md"
+Issues = "https://github.com/HVallad/LatticeLens/issues"
+
 [project.optional-dependencies]
 dev = [
     "pytest>=8.0.0",
     "pytest-cov>=6.0.0",
     "ruff>=0.3.0",
+    "build>=1.0.0",
 ]
 extract = [
     "anthropic>=0.25.0",


### PR DESCRIPTION
## Summary
- Add GitHub Actions publish workflow using Trusted Publishers (OIDC, no API tokens)
- Pipeline: build + twine check -> TestPyPI -> PyPI, triggered on GitHub Release
- Add PyPI metadata to pyproject.toml: author, classifiers, URLs, readme, SPDX license format
- Add `build` to dev dependencies

## Setup required after merge
1. Create GitHub Environments: `test-pypi` and `pypi`
2. Register Trusted Publishers on [test.pypi.org](https://test.pypi.org/manage/account/publishing/) and [pypi.org](https://pypi.org/manage/account/publishing/):
   - Owner: `HVallad`, Repo: `LatticeLens`, Workflow: `publish.yml`
   - Environment: `test-pypi` / `pypi` respectively
3. Create a GitHub Release with tag `v1.0.0` to trigger first publish

## Test plan
- [x] `python -m build` produces valid sdist + wheel
- [x] `twine check dist/*` passes
- [ ] Create test release to verify end-to-end workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)