### PR TITLE
Fix publish workflow version extraction

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,7 +47,9 @@ jobs:
       - name: Verify install from TestPyPI
         run: |
           sleep 15
-          pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ lattice-lens==${{ github.event.release.tag_name#v }}
+          VERSION="${{ github.event.release.tag_name }}"
+          VERSION="${VERSION#v}"
+          pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ lattice-lens=="${VERSION}"
 
   pypi:
     name: Publish to PyPI


### PR DESCRIPTION
## Summary
- Fix bash string trimming syntax that doesn't work inside `${{ }}` expressions
- Move `v` prefix stripping to a shell variable in the TestPyPI verify step

## Context
The `${{ github.event.release.tag_name#v }}` syntax is invalid in GitHub Actions expressions. The `#v` trim operator only works in bash, not in the Actions expression engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)