### PR TITLE
Fix viewer permanent expansion (#29)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -109,7 +109,7 @@ function AppInner() {
   const allCodes = useMemo(() => facts.map((f) => f.code), [facts]);
 
   const handleSelectCode = useCallback((code: string) => {
-    setSelectedCode(code || null);
+    setSelectedCode((prev) => (code && code === prev ? null : code || null));
   }, []);
 
   const handleDoubleClickNode = useCallback(
@@ -256,7 +256,7 @@ function AppInner() {
         <Sidebar
           facts={facts}
           selectedCode={selectedCode}
-          selectedFact={selectedFactQuery.data || null}
+          selectedFact={selectedCode ? selectedFactQuery.data || null : null}
           matchingCodes={matchingCodes}
           onSelect={handleSelectCode}
           onPromote={handlePromote}


### PR DESCRIPTION
## Summary
- Fix React Query stale data causing sidebar to stay expanded after deselecting a fact
- Add toggle behavior to `handleSelectCode` — clicking an already-selected fact now deselects it

## Root Cause
1. `useFact(null)` query was disabled but React Query retained last `data`, so `Sidebar` always received a non-null `selectedFact`
2. `handleSelectCode` always set the code without toggle check

## Test Plan
- [ ] Open viewer, click a fact — sidebar expands
- [ ] Click same fact again — sidebar collapses (was broken, now fixed)
- [ ] Click a different fact — sidebar shows new fact
- [ ] Click graph node — same toggle behavior

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)