### PR TITLE
Add toggleable legend to viewer graph (#34)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import { Sidebar } from './components/layout/Sidebar';
 import { EditPanel } from './components/layout/EditPanel';
 import { GraphCanvas } from './components/graph/GraphCanvas';
 import { GraphControls } from './components/graph/GraphControls';
+import { GraphLegend } from './components/graph/GraphLegend';
 import { SearchBar } from './components/search/SearchBar';
 import { FilterPanel } from './components/search/FilterPanel';
 import { ThemeToggle } from './components/common/ThemeToggle';
@@ -282,6 +283,7 @@ function AppInner() {
           onSelectNode={handleSelectCode}
           onDoubleClickNode={handleDoubleClickNode}
         />
+        <GraphLegend />
       </div>
 
       {/* Edit Panel */}

--- a/frontend/src/components/graph/GraphLegend.tsx
+++ b/frontend/src/components/graph/GraphLegend.tsx
@@ -1,0 +1,97 @@
+import { useState } from 'react';
+import { STATUS_COLORS, LAYER_COLORS, EDGE_STYLES } from '../../utils/colors';
+import type { FactStatus, FactLayer, EdgeType } from '../../types/fact';
+
+const LAYER_SHAPES: Record<FactLayer, string> = {
+  WHY: 'circle',
+  GUARDRAILS: 'diamond',
+  HOW: 'square',
+};
+
+export function GraphLegend() {
+  const [visible, setVisible] = useState(true);
+
+  if (!visible) {
+    return (
+      <button
+        className="btn btn-sm graph-legend-toggle"
+        onClick={() => setVisible(true)}
+        title="Show legend"
+      >
+        Legend
+      </button>
+    );
+  }
+
+  return (
+    <div className="graph-legend">
+      <div className="legend-header">
+        <span className="legend-title">Legend</span>
+        <button
+          className="legend-close"
+          onClick={() => setVisible(false)}
+          title="Hide legend"
+        >
+          &times;
+        </button>
+      </div>
+
+      {/* Node shapes by layer */}
+      <div className="legend-section">
+        <div className="legend-section-title">Layers (shape)</div>
+        {(Object.entries(LAYER_SHAPES) as [FactLayer, string][]).map(([layer, shape]) => (
+          <div className="legend-row" key={layer}>
+            <svg className="legend-shape" viewBox="0 0 14 14">
+              {shape === 'circle' && (
+                <circle cx="7" cy="7" r="6" fill={LAYER_COLORS[layer]} />
+              )}
+              {shape === 'diamond' && (
+                <polygon points="7,1 13,7 7,13 1,7" fill={LAYER_COLORS[layer]} />
+              )}
+              {shape === 'square' && (
+                <rect x="1" y="1" width="12" height="12" rx="2" fill={LAYER_COLORS[layer]} />
+              )}
+            </svg>
+            <span>{layer}</span>
+          </div>
+        ))}
+      </div>
+
+      {/* Node colors by status */}
+      <div className="legend-section">
+        <div className="legend-section-title">Status (color)</div>
+        {(Object.entries(STATUS_COLORS) as [FactStatus, string][]).map(([status, color]) => (
+          <div className="legend-row" key={status}>
+            <svg className="legend-shape" viewBox="0 0 14 14">
+              <circle cx="7" cy="7" r="6" fill={color} />
+            </svg>
+            <span>{status}</span>
+          </div>
+        ))}
+      </div>
+
+      {/* Edge types */}
+      <div className="legend-section">
+        <div className="legend-section-title">Edges (relationship)</div>
+        {(Object.entries(EDGE_STYLES) as [EdgeType, { color: string; dash: string }][]).map(
+          ([rel, style]) => (
+            <div className="legend-row" key={rel}>
+              <svg className="legend-line" viewBox="0 0 28 4">
+                <line
+                  x1="0"
+                  y1="2"
+                  x2="28"
+                  y2="2"
+                  stroke={style.color}
+                  strokeWidth="2"
+                  strokeDasharray={style.dash || undefined}
+                />
+              </svg>
+              <span>{rel.replace('_', ' ')}</span>
+            </div>
+          )
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -523,29 +523,82 @@ body {
   background: var(--bg-secondary);
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  padding: 8px 12px;
+  padding: 10px 14px;
   font-size: 11px;
   z-index: 10;
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 8px;
+  max-height: calc(100% - 24px);
+  overflow-y: auto;
+  box-shadow: var(--shadow);
+}
+
+.graph-legend-toggle {
+  position: absolute;
+  bottom: 12px;
+  left: 12px;
+  z-index: 10;
+}
+
+.legend-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.legend-title {
+  font-weight: 600;
+  font-size: 12px;
+  color: var(--text-primary);
+}
+
+.legend-close {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 16px;
+  line-height: 1;
+  padding: 0 2px;
+}
+
+.legend-close:hover {
+  color: var(--text-primary);
+}
+
+.legend-section {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.legend-section-title {
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted);
+  margin-bottom: 2px;
 }
 
 .legend-row {
   display: flex;
   align-items: center;
   gap: 6px;
+  color: var(--text-secondary);
 }
 
 .legend-shape {
-  width: 12px;
-  height: 12px;
+  width: 14px;
+  height: 14px;
   flex-shrink: 0;
 }
 
 .legend-line {
-  width: 24px;
-  height: 2px;
+  width: 28px;
+  height: 4px;
   flex-shrink: 0;
 }
 


### PR DESCRIPTION
## Summary
- New `GraphLegend` component with show/hide toggle
- Three sections: Layers (shape), Status (color), Edges (relationship)
- Uses existing `LAYER_COLORS`, `STATUS_COLORS`, `EDGE_STYLES` constants
- Styled to match existing dark theme

## Test Plan
- [ ] Open viewer, click Legend button — legend appears
- [ ] Legend shows correct shapes for WHY/GUARDRAILS/HOW layers
- [ ] Legend shows correct colors for Active/Draft/Under Review/Deprecated/Superseded
- [ ] All 9 edge types displayed with correct line styles
- [ ] Close button hides legend
- [ ] 211 tests pass

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)