### PR TITLE
Add fact access count tracking (#33)

### DIFF
--- a/.claude/skills/lattice/SKILL.md
+++ b/.claude/skills/lattice/SKILL.md
@@ -131,6 +131,31 @@ New facts default to `Draft`. They must be promoted through `Under Review` to `A
 lattice fact deprecate ADR-03 --reason "Superseded by ADR-04"
 ```
 
+### Fact Access Tracking
+
+Track how often facts are accessed to identify unused or over-relied-on facts:
+
+```bash
+# Show access counts for all facts
+lattice fact stats
+
+# Find unused or stale facts (for pruning)
+lattice fact stats --cold
+lattice fact stats --cold --days 14     # not accessed in 14 days
+
+# Find most accessed facts
+lattice fact stats --hot
+lattice fact stats --hot --top 5
+
+# Check a specific fact
+lattice fact stats ADR-01
+
+# Machine-readable output
+lattice fact stats --json
+```
+
+Access is tracked automatically when facts are read via CLI, context assembly, API, or MCP. Stored in `.lattice/access_log.yaml` (not committed — instance-specific).
+
 ## Knowledge Graph (Phase 2)
 
 ### Impact analysis

--- a/.lattice/.gitignore
+++ b/.lattice/.gitignore
@@ -1,3 +1,4 @@
 # LatticeLens generated files
 index.yaml
 *.bak/
+access_log.yaml

--- a/src/lattice_lens/cli/context_commands.py
+++ b/src/lattice_lens/cli/context_commands.py
@@ -54,6 +54,16 @@ def context(
         store.index, role, template, budget=budget, project=project, graph_depth=depth
     )
 
+    # Track access for all loaded facts (never let tracking failures break core)
+    try:
+        from lattice_lens.services.access_service import get_tracker
+
+        tracker = get_tracker(store.root)
+        for fact in result.loaded_facts:
+            tracker.record_access(fact.code, source="context")
+    except Exception:
+        pass
+
     if as_json:
         print(json.dumps(result.to_dict(), indent=2))
         return

--- a/src/lattice_lens/cli/fact_commands.py
+++ b/src/lattice_lens/cli/fact_commands.py
@@ -186,6 +186,15 @@ def fact_get(
         err_console.print(f"[red]Error:[/red] Fact '{code}' not found")
         raise typer.Exit(1)
 
+    # Track access (never let tracking failures break core functionality)
+    try:
+        from lattice_lens.services.access_service import get_tracker
+
+        tracker = get_tracker(store.root)
+        tracker.record_access(code, source="cli")
+    except Exception:
+        pass
+
     if as_json:
         print(json.dumps(fact.model_dump(mode="json"), indent=2))
         return
@@ -527,3 +536,207 @@ def fact_deprecate(
 
     result = store.deprecate(code, reason)
     console.print(f"[green]Deprecated[/green] {result.code} (v{result.version}): {reason}")
+
+
+@fact_app.command("stats")
+def fact_stats(
+    code: Optional[str] = typer.Argument(None, help="Specific fact code to show stats for"),
+    cold: bool = typer.Option(False, "--cold", help="Show facts never accessed or stale"),
+    hot: bool = typer.Option(False, "--hot", help="Show most accessed facts"),
+    days: int = typer.Option(30, "--days", help="Days threshold for cold facts"),
+    top: int = typer.Option(10, "--top", help="Number of top facts for --hot"),
+    as_json: bool = typer.Option(False, "--json", help="Machine-readable JSON output"),
+):
+    """Show access count statistics for facts."""
+    from lattice_lens.services.access_service import get_tracker
+
+    store = require_lattice()
+    tracker = get_tracker(store.root)
+
+    # Ensure all known facts appear in the output (even if never accessed)
+    all_codes = store.all_codes()
+    counts = tracker.get_counts()
+
+    if code is not None:
+        # Show stats for a specific fact
+        if not store.exists(code):
+            err_console.print(f"[red]Error:[/red] Fact '{code}' not found")
+            raise typer.Exit(1)
+
+        fact = store.get(code)
+        entry = counts.get(
+            code, {"count": 0, "last_accessed": None, "first_accessed": None, "sources": {}}
+        )
+
+        if as_json:
+            print(json.dumps({"code": code, **entry}, indent=2))
+            return
+
+        sources_display = ", ".join(f"{k}:{v}" for k, v in sorted(entry.get("sources", {}).items()))
+
+        content = (
+            f"[bold]Count:[/bold] {entry['count']}\n"
+            f"[bold]First accessed:[/bold] {entry.get('first_accessed') or 'never'}\n"
+            f"[bold]Last accessed:[/bold] {entry.get('last_accessed') or 'never'}\n"
+            f"[bold]Sources:[/bold] {sources_display or '(none)'}"
+        )
+        title = f"{code}"
+        if fact:
+            title += f" — {fact.type}"
+        console.print(Panel(content, title=f"[bold]{title}[/bold]", border_style="blue"))
+        return
+
+    if cold:
+        # Show cold facts
+        cold_facts = tracker.get_cold_facts(threshold=0, days=days)
+
+        # Also include facts that have never been tracked at all
+        tracked_codes = set(counts.keys())
+        for c in sorted(all_codes):
+            if c not in tracked_codes:
+                cold_facts.append(
+                    {"code": c, "count": 0, "last_accessed": None, "days_since": None}
+                )
+
+        if as_json:
+            print(json.dumps(cold_facts, indent=2))
+            return
+
+        if not cold_facts:
+            console.print("[dim]No cold facts found.[/dim]")
+            return
+
+        table = Table(title=f"Cold Facts (threshold=0, days={days})")
+        table.add_column("Code", style="bold")
+        table.add_column("Title")
+        table.add_column("Count", justify="right")
+        table.add_column("Last Accessed")
+
+        for item in cold_facts:
+            fact = store.get(item["code"])
+            title = fact.type if fact else "?"
+            last = item.get("last_accessed") or "never"
+            count_str = str(item["count"])
+            style = "red" if item["count"] == 0 else "yellow"
+            table.add_row(
+                f"[{style}]{item['code']}[/{style}]",
+                title,
+                count_str,
+                last if last == "never" else _relative_time(last),
+            )
+
+        console.print(table)
+        return
+
+    if hot:
+        # Show hot facts
+        hot_facts = tracker.get_hot_facts(top_k=top)
+
+        if as_json:
+            print(json.dumps(hot_facts, indent=2))
+            return
+
+        if not hot_facts:
+            console.print("[dim]No access data recorded yet.[/dim]")
+            return
+
+        table = Table(title=f"Hot Facts (top {top})")
+        table.add_column("Code", style="bold")
+        table.add_column("Title")
+        table.add_column("Count", justify="right")
+        table.add_column("Last Accessed")
+        table.add_column("Sources")
+
+        for item in hot_facts:
+            fact = store.get(item["code"])
+            title = fact.type if fact else "?"
+            sources = ", ".join(f"{k}:{v}" for k, v in sorted(item.get("sources", {}).items()))
+            last = item.get("last_accessed") or "never"
+            table.add_row(
+                f"[green]{item['code']}[/green]",
+                title,
+                str(item["count"]),
+                last if last == "never" else _relative_time(last),
+                sources or "-",
+            )
+
+        console.print(table)
+        return
+
+    # Default: show all facts with their access counts
+    rows: list[dict] = []
+    for c in sorted(all_codes):
+        entry = counts.get(c, {"count": 0, "last_accessed": None, "sources": {}})
+        fact = store.get(c)
+        rows.append(
+            {
+                "code": c,
+                "title": fact.type if fact else "?",
+                "count": entry.get("count", 0),
+                "last_accessed": entry.get("last_accessed"),
+                "sources": entry.get("sources", {}),
+            }
+        )
+
+    if as_json:
+        print(json.dumps(rows, indent=2))
+        return
+
+    if not rows:
+        console.print("[dim]No facts in lattice.[/dim]")
+        return
+
+    table = Table(title="Fact Access Statistics")
+    table.add_column("Code", style="bold")
+    table.add_column("Title")
+    table.add_column("Count", justify="right")
+    table.add_column("Last Accessed")
+    table.add_column("Sources")
+
+    for row in rows:
+        sources = ", ".join(f"{k}:{v}" for k, v in sorted(row["sources"].items()))
+        last = row["last_accessed"] or "never"
+        count = row["count"]
+
+        # Color coding: hot=green, cold=red, middle=default
+        if count == 0:
+            code_style = "red"
+        elif count >= 10:
+            code_style = "green"
+        else:
+            code_style = "yellow"
+
+        table.add_row(
+            f"[{code_style}]{row['code']}[/{code_style}]",
+            row["title"],
+            str(count),
+            last if last == "never" else _relative_time(last),
+            sources or "-",
+        )
+
+    console.print(table)
+
+
+def _relative_time(iso_str: str) -> str:
+    """Convert ISO timestamp to a human-readable relative time string."""
+    from datetime import datetime, timezone
+
+    try:
+        dt = datetime.fromisoformat(iso_str)
+        now = datetime.now(timezone.utc)
+        delta = now - dt
+        seconds = int(delta.total_seconds())
+
+        if seconds < 60:
+            return "just now"
+        elif seconds < 3600:
+            mins = seconds // 60
+            return f"{mins} min{'s' if mins != 1 else ''} ago"
+        elif seconds < 86400:
+            hours = seconds // 3600
+            return f"{hours} hour{'s' if hours != 1 else ''} ago"
+        else:
+            d = seconds // 86400
+            return f"{d} day{'s' if d != 1 else ''} ago"
+    except Exception:
+        return iso_str

--- a/src/lattice_lens/mcp/tools.py
+++ b/src/lattice_lens/mcp/tools.py
@@ -22,11 +22,21 @@ from lattice_lens.store.protocol import LatticeStore
 # ── Read Tools ──
 
 
-def tool_fact_get(store: LatticeStore, code: str) -> dict:
+def tool_fact_get(store: LatticeStore, code: str, source: str = "mcp") -> dict:
     """Get a single fact by its code."""
     fact = store.get(code)
     if fact is None:
         return {"error": f"Fact {code} not found"}
+
+    # Track access (never let tracking failures break core functionality)
+    try:
+        from lattice_lens.services.access_service import get_tracker
+
+        tracker = get_tracker(store.root)
+        tracker.record_access(code, source=source)
+    except Exception:
+        pass
+
     return fact.model_dump(mode="json")
 
 
@@ -71,6 +81,17 @@ def tool_context_assemble(
 
     template = templates[role]
     result = context_service.assemble_context(store.index, role, template, budget=budget)
+
+    # Track access for all loaded facts (never let tracking failures break core)
+    try:
+        from lattice_lens.services.access_service import get_tracker
+
+        tracker = get_tracker(store.root)
+        for f in result.loaded_facts:
+            tracker.record_access(f.code, source="mcp")
+    except Exception:
+        pass
+
     return {
         "role": result.role,
         "budget": {

--- a/src/lattice_lens/services/access_service.py
+++ b/src/lattice_lens/services/access_service.py
@@ -1,0 +1,177 @@
+"""Fact access tracking for maintenance and pruning.
+
+Tracks how many times each fact is accessed/pulled so teams can identify
+unused, low-priority, or incorrectly tagged facts that agents are missing.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+from ruamel.yaml import YAML
+
+ACCESS_LOG_FILE = "access_log.yaml"
+
+yaml = YAML()
+yaml.default_flow_style = False
+
+
+class AccessTracker:
+    """Tracks fact access counts. Stored in .lattice/access_log.yaml."""
+
+    def __init__(self, lattice_root: Path):
+        self.log_path = lattice_root / ACCESS_LOG_FILE
+        self.data: dict[str, dict] = self._load()
+
+    def _load(self) -> dict[str, dict]:
+        """Load access log from YAML file. Returns empty dict if missing."""
+        if not self.log_path.exists():
+            return {}
+        with open(self.log_path) as f:
+            raw = yaml.load(f)
+        if raw is None:
+            return {}
+        # Normalize loaded data to plain dicts
+        result: dict[str, dict] = {}
+        for code, entry in raw.items():
+            result[str(code)] = {
+                "count": int(entry.get("count", 0)),
+                "last_accessed": entry.get("last_accessed"),
+                "first_accessed": entry.get("first_accessed"),
+                "sources": dict(entry.get("sources", {})),
+            }
+        return result
+
+    def record_access(self, code: str, source: str = "unknown") -> None:
+        """Record a fact being accessed.
+
+        Args:
+            code: The fact code (e.g., ADR-01).
+            source: Access source — one of "cli", "context", "api", "mcp", "search".
+        """
+        now = datetime.now(timezone.utc).isoformat()
+
+        if code not in self.data:
+            self.data[code] = {
+                "count": 0,
+                "last_accessed": None,
+                "first_accessed": now,
+                "sources": {},
+            }
+
+        entry = self.data[code]
+        entry["count"] = entry.get("count", 0) + 1
+        entry["last_accessed"] = now
+        if entry.get("first_accessed") is None:
+            entry["first_accessed"] = now
+
+        sources = entry.setdefault("sources", {})
+        sources[source] = sources.get(source, 0) + 1
+
+        self.save()
+
+    def get_counts(self) -> dict[str, dict]:
+        """Return {code: {count, last_accessed, first_accessed, sources}} for all facts."""
+        return dict(self.data)
+
+    def get_stats(self, code: str) -> dict | None:
+        """Return stats for a specific fact code, or None if not tracked."""
+        return self.data.get(code)
+
+    def get_cold_facts(self, threshold: int = 0, days: int = 30) -> list[dict]:
+        """Find facts never accessed or not accessed in N days.
+
+        Args:
+            threshold: Maximum access count to be considered cold (default 0 = never accessed).
+            days: Facts not accessed in this many days are cold.
+
+        Returns:
+            List of {code, count, last_accessed, days_since} dicts, sorted by count ascending.
+        """
+        now = datetime.now(timezone.utc)
+        results: list[dict] = []
+
+        for code, entry in self.data.items():
+            count = entry.get("count", 0)
+            last = entry.get("last_accessed")
+
+            if count <= threshold:
+                days_since = None
+                if last:
+                    last_dt = datetime.fromisoformat(last)
+                    days_since = (now - last_dt).days
+                results.append(
+                    {"code": code, "count": count, "last_accessed": last, "days_since": days_since}
+                )
+                continue
+
+            if last:
+                last_dt = datetime.fromisoformat(last)
+                days_since = (now - last_dt).days
+                if days_since >= days:
+                    results.append(
+                        {
+                            "code": code,
+                            "count": count,
+                            "last_accessed": last,
+                            "days_since": days_since,
+                        }
+                    )
+
+        results.sort(key=lambda x: x["count"])
+        return results
+
+    def get_hot_facts(self, top_k: int = 10) -> list[dict]:
+        """Find most frequently accessed facts.
+
+        Args:
+            top_k: Number of top facts to return.
+
+        Returns:
+            List of {code, count, last_accessed, sources} dicts, sorted by count descending.
+        """
+        items = [
+            {
+                "code": code,
+                "count": entry.get("count", 0),
+                "last_accessed": entry.get("last_accessed"),
+                "sources": entry.get("sources", {}),
+            }
+            for code, entry in self.data.items()
+        ]
+        items.sort(key=lambda x: x["count"], reverse=True)
+        return items[:top_k]
+
+    def reset(self, code: str | None = None) -> None:
+        """Reset counts for one fact or all facts.
+
+        Args:
+            code: If provided, reset only this fact. Otherwise reset all.
+        """
+        if code is not None:
+            if code in self.data:
+                self.data[code] = {
+                    "count": 0,
+                    "last_accessed": None,
+                    "first_accessed": None,
+                    "sources": {},
+                }
+        else:
+            self.data = {}
+        self.save()
+
+    def save(self) -> None:
+        """Persist access log to access_log.yaml."""
+        # Ensure parent directory exists
+        self.log_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(self.log_path, "w") as f:
+            yaml.dump(dict(self.data) if self.data else {}, f)
+
+
+def get_tracker(lattice_root: Path) -> AccessTracker:
+    """Create an AccessTracker for the given lattice root.
+
+    This is the primary entry point for obtaining a tracker instance.
+    """
+    return AccessTracker(lattice_root)

--- a/src/lattice_lens/web/api/facts.py
+++ b/src/lattice_lens/web/api/facts.py
@@ -80,7 +80,7 @@ def create_facts_router() -> APIRouter:
     async def get_fact(code: str, request: Request):
         """Get a single fact by code."""
         store = request.app.state.store
-        return tool_fact_get(store, code)
+        return tool_fact_get(store, code, source="api")
 
     @router.post("/facts")
     async def create_fact(body: FactCreateRequest, request: Request):

--- a/src/lattice_lens/web/api/graph.py
+++ b/src/lattice_lens/web/api/graph.py
@@ -25,6 +25,18 @@ def create_graph_router() -> APIRouter:
         if not include_inactive:
             excluded_statuses = {FactStatus.DEPRECATED, FactStatus.SUPERSEDED}
 
+        # Load access counts for node metadata (optional — never breaks graph)
+        access_counts: dict[str, int] = {}
+        try:
+            from lattice_lens.services.access_service import get_tracker
+
+            lattice_root = request.app.state.lattice_root
+            tracker = get_tracker(lattice_root)
+            counts = tracker.get_counts()
+            access_counts = {code: entry.get("count", 0) for code, entry in counts.items()}
+        except Exception:
+            pass
+
         nodes = []
         edges = []
 
@@ -42,6 +54,7 @@ def create_graph_router() -> APIRouter:
                     "fact": fact.fact,
                     "owner": fact.owner,
                     "version": fact.version,
+                    "access_count": access_counts.get(fact.code, 0),
                 }
             )
 

--- a/src/lattice_lens/web/api/meta.py
+++ b/src/lattice_lens/web/api/meta.py
@@ -67,6 +67,18 @@ def create_meta_router() -> APIRouter:
         store = request.app.state.store
         index = store.index
         result = assemble_context(index, role_name, templates[role_name], project=project)
+
+        # Track access for assembled facts
+        try:
+            from lattice_lens.services.access_service import get_tracker
+
+            lattice_root = request.app.state.lattice_root
+            tracker = get_tracker(lattice_root)
+            for f in result.loaded_facts:
+                tracker.record_access(f.code, source="api")
+        except Exception:
+            pass
+
         return {
             "role": role_name,
             "facts_loaded": result.to_dict()["facts_loaded"],

--- a/tests/test_access_tracking.py
+++ b/tests/test_access_tracking.py
@@ -1,0 +1,271 @@
+"""Tests for fact access count tracking (access_service)."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from lattice_lens.services.access_service import AccessTracker, get_tracker
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def tracker(tmp_lattice: Path) -> AccessTracker:
+    """Return an AccessTracker pointed at a temp .lattice/ dir."""
+    return get_tracker(tmp_lattice)
+
+
+class TestRecordAccess:
+    def test_increments_count(self, tracker: AccessTracker):
+        tracker.record_access("ADR-01", source="cli")
+        tracker.record_access("ADR-01", source="cli")
+        tracker.record_access("ADR-01", source="api")
+
+        counts = tracker.get_counts()
+        assert counts["ADR-01"]["count"] == 3
+
+    def test_tracks_sources(self, tracker: AccessTracker):
+        tracker.record_access("ADR-01", source="cli")
+        tracker.record_access("ADR-01", source="cli")
+        tracker.record_access("ADR-01", source="context")
+        tracker.record_access("ADR-01", source="api")
+
+        entry = tracker.get_counts()["ADR-01"]
+        assert entry["sources"]["cli"] == 2
+        assert entry["sources"]["context"] == 1
+        assert entry["sources"]["api"] == 1
+
+    def test_tracks_timestamps(self, tracker: AccessTracker):
+        tracker.record_access("ADR-01", source="cli")
+        entry = tracker.get_counts()["ADR-01"]
+
+        assert entry["first_accessed"] is not None
+        assert entry["last_accessed"] is not None
+        # first_accessed should be set
+        dt = datetime.fromisoformat(entry["first_accessed"])
+        assert dt.tzinfo is not None  # Should be timezone-aware
+
+    def test_first_accessed_stays_constant(self, tracker: AccessTracker):
+        tracker.record_access("ADR-01", source="cli")
+        first = tracker.get_counts()["ADR-01"]["first_accessed"]
+
+        tracker.record_access("ADR-01", source="cli")
+        assert tracker.get_counts()["ADR-01"]["first_accessed"] == first
+
+    def test_multiple_codes(self, tracker: AccessTracker):
+        tracker.record_access("ADR-01", source="cli")
+        tracker.record_access("RISK-01", source="api")
+        tracker.record_access("ADR-01", source="mcp")
+
+        counts = tracker.get_counts()
+        assert counts["ADR-01"]["count"] == 2
+        assert counts["RISK-01"]["count"] == 1
+
+    def test_default_source(self, tracker: AccessTracker):
+        tracker.record_access("ADR-01")
+        entry = tracker.get_counts()["ADR-01"]
+        assert entry["sources"]["unknown"] == 1
+
+
+class TestGetStats:
+    def test_returns_none_for_untracked(self, tracker: AccessTracker):
+        assert tracker.get_stats("NEVER-01") is None
+
+    def test_returns_stats_for_tracked(self, tracker: AccessTracker):
+        tracker.record_access("ADR-01", source="cli")
+        stats = tracker.get_stats("ADR-01")
+        assert stats is not None
+        assert stats["count"] == 1
+
+
+class TestColdFacts:
+    def test_finds_never_accessed(self, tracker: AccessTracker):
+        tracker.data["ADR-01"] = {
+            "count": 0,
+            "last_accessed": None,
+            "first_accessed": None,
+            "sources": {},
+        }
+        tracker.data["ADR-02"] = {
+            "count": 5,
+            "last_accessed": datetime.now(timezone.utc).isoformat(),
+            "first_accessed": datetime.now(timezone.utc).isoformat(),
+            "sources": {"cli": 5},
+        }
+
+        cold = tracker.get_cold_facts(threshold=0, days=30)
+        codes = [c["code"] for c in cold]
+        assert "ADR-01" in codes
+        assert "ADR-02" not in codes
+
+    def test_threshold_parameter(self, tracker: AccessTracker):
+        tracker.record_access("ADR-01", source="cli")
+        tracker.record_access("ADR-02", source="cli")
+        tracker.record_access("ADR-02", source="cli")
+
+        cold = tracker.get_cold_facts(threshold=1, days=9999)
+        codes = [c["code"] for c in cold]
+        assert "ADR-01" in codes  # count=1 <= threshold=1
+        assert "ADR-02" not in codes  # count=2 > threshold=1
+
+    def test_sorted_by_count(self, tracker: AccessTracker):
+        tracker.data["B-01"] = {
+            "count": 0,
+            "last_accessed": None,
+            "first_accessed": None,
+            "sources": {},
+        }
+        tracker.data["A-01"] = {
+            "count": 0,
+            "last_accessed": None,
+            "first_accessed": None,
+            "sources": {},
+        }
+
+        cold = tracker.get_cold_facts()
+        # Both have count 0, should be sorted
+        assert len(cold) == 2
+
+
+class TestHotFacts:
+    def test_ordering(self, tracker: AccessTracker):
+        for _ in range(5):
+            tracker.record_access("ADR-01", source="cli")
+        for _ in range(10):
+            tracker.record_access("RISK-01", source="api")
+        tracker.record_access("SP-01", source="mcp")
+
+        hot = tracker.get_hot_facts(top_k=3)
+        assert hot[0]["code"] == "RISK-01"
+        assert hot[0]["count"] == 10
+        assert hot[1]["code"] == "ADR-01"
+        assert hot[1]["count"] == 5
+        assert hot[2]["code"] == "SP-01"
+        assert hot[2]["count"] == 1
+
+    def test_top_k_limit(self, tracker: AccessTracker):
+        for i in range(20):
+            tracker.record_access(f"ADR-{i:02d}", source="cli")
+
+        hot = tracker.get_hot_facts(top_k=5)
+        assert len(hot) == 5
+
+    def test_empty(self, tracker: AccessTracker):
+        hot = tracker.get_hot_facts()
+        assert hot == []
+
+
+class TestSaveLoadRoundTrip:
+    def test_persist_and_reload(self, tmp_lattice: Path):
+        tracker1 = get_tracker(tmp_lattice)
+        tracker1.record_access("ADR-01", source="cli")
+        tracker1.record_access("ADR-01", source="api")
+        tracker1.record_access("RISK-01", source="context")
+
+        # Create a new tracker instance — should load from disk
+        tracker2 = get_tracker(tmp_lattice)
+        counts = tracker2.get_counts()
+        assert counts["ADR-01"]["count"] == 2
+        assert counts["ADR-01"]["sources"]["cli"] == 1
+        assert counts["ADR-01"]["sources"]["api"] == 1
+        assert counts["RISK-01"]["count"] == 1
+
+    def test_empty_file_loads_safely(self, tmp_lattice: Path):
+        # Write an empty file
+        log_path = tmp_lattice / "access_log.yaml"
+        log_path.write_text("")
+
+        tracker = get_tracker(tmp_lattice)
+        assert tracker.get_counts() == {}
+
+    def test_missing_file_loads_safely(self, tmp_lattice: Path):
+        tracker = get_tracker(tmp_lattice)
+        assert tracker.get_counts() == {}
+
+
+class TestReset:
+    def test_reset_single(self, tracker: AccessTracker):
+        tracker.record_access("ADR-01", source="cli")
+        tracker.record_access("RISK-01", source="api")
+
+        tracker.reset("ADR-01")
+
+        assert tracker.get_counts()["ADR-01"]["count"] == 0
+        assert tracker.get_counts()["RISK-01"]["count"] == 1
+
+    def test_reset_all(self, tracker: AccessTracker):
+        tracker.record_access("ADR-01", source="cli")
+        tracker.record_access("RISK-01", source="api")
+
+        tracker.reset()
+        assert tracker.get_counts() == {}
+
+    def test_reset_nonexistent_code(self, tracker: AccessTracker):
+        # Should not raise
+        tracker.reset("NONEXISTENT-99")
+        assert tracker.get_counts() == {}
+
+
+class TestCLIStats:
+    """Test the CLI `lattice fact stats` command output."""
+
+    def test_stats_default(self, seeded_store):
+        from lattice_lens.cli.main import app
+
+        result = runner.invoke(app, ["fact", "stats"])
+        assert result.exit_code == 0
+        assert "Fact Access Statistics" in result.output
+
+    def test_stats_json(self, seeded_store):
+        from lattice_lens.cli.main import app
+
+        result = runner.invoke(app, ["fact", "stats", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert isinstance(data, list)
+
+    def test_stats_cold(self, seeded_store):
+        from lattice_lens.cli.main import app
+
+        result = runner.invoke(app, ["fact", "stats", "--cold"])
+        assert result.exit_code == 0
+        assert "Cold Facts" in result.output
+
+    def test_stats_hot(self, seeded_store):
+        from lattice_lens.cli.main import app
+
+        result = runner.invoke(app, ["fact", "stats", "--hot"])
+        assert result.exit_code == 0
+        # With no access data yet, should show empty message
+        assert "No access data" in result.output or "Hot Facts" in result.output
+
+    def test_stats_specific_code(self, seeded_store):
+        from lattice_lens.cli.main import app
+
+        # Get a code from the seeded store
+        codes = seeded_store.all_codes()
+        assert len(codes) > 0
+        code = sorted(codes)[0]
+
+        result = runner.invoke(app, ["fact", "stats", code])
+        assert result.exit_code == 0
+        assert "Count:" in result.output
+
+    def test_stats_specific_code_not_found(self, seeded_store):
+        from lattice_lens.cli.main import app
+
+        result = runner.invoke(app, ["fact", "stats", "NONEXISTENT-99"])
+        assert result.exit_code == 1
+
+    def test_stats_cold_json(self, seeded_store):
+        from lattice_lens.cli.main import app
+
+        result = runner.invoke(app, ["fact", "stats", "--cold", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert isinstance(data, list)


### PR DESCRIPTION
## Summary
- `AccessTracker` service persisting to `.lattice/access_log.yaml`
- Tracks count, timestamps, and source breakdown (cli, context, api, mcp, search) per fact
- `lattice fact stats` command with `--cold`, `--hot`, `--days`, `--top`, `--json` options
- Rich color-coded table output (green=hot, red=cold)

## Instrumented Access Points
- `lattice fact get` (source: cli)
- `lattice context` assembly (source: context)
- MCP `tool_fact_get` (source: mcp)
- Web API fact endpoint (source: api)
- Graph endpoint includes `access_count` per node for optional size visualization

## Details
- All tracker calls wrapped in try/except — tracking failures never break core functionality
- `access_log.yaml` added to `.lattice/.gitignore` (instance-specific)
- 27 new tests covering counts, sources, cold/hot queries, persistence, CLI output

## Test Plan
- [x] 27 unit tests pass
- [ ] `lattice fact get DG-01` then `lattice fact stats` shows count=1
- [ ] `lattice fact stats --cold` shows facts with 0 access
- [ ] `lattice fact stats --hot` shows most accessed facts
- [ ] Graph API includes access_count in node data

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)