### PR TITLE
Add configurable embedding model — lattice config embedding command

### DIFF
--- a/.lattice/config.yaml
+++ b/.lattice/config.yaml
@@ -3,3 +3,12 @@ backend: yaml
 auto_promote:
   enabled: false
   threshold_days: 14
+
+# Embedding model for semantic search
+# Popular alternatives:
+# model: "BAAI/bge-small-en-v1.5"       # better quality, same speed
+# model: "all-mpnet-base-v2"            # best quality, slower
+# model: "nomic-ai/nomic-embed-text-v1.5"  # near SOTA
+# model: "Snowflake/snowflake-arctic-embed-s"  # good balance
+embedding:
+  model: all-MiniLM-L6-v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,10 @@ extract = [
 mcp = [
     "mcp[cli]>=1.2.0",
 ]
+semantic = [
+    "sentence-transformers>=2.0",
+    "numpy",
+]
 viewer = [
     "fastapi>=0.110.0",
     "uvicorn[standard]>=0.27.0",

--- a/src/lattice_lens/cli/config_command.py
+++ b/src/lattice_lens/cli/config_command.py
@@ -1,0 +1,154 @@
+"""lattice config — configuration management commands."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from lattice_lens.cli.helpers import is_lens_mode
+from lattice_lens.config import find_lattice_root, load_config, save_config
+from lattice_lens.services.embedding_service import (
+    DEFAULT_MODEL,
+    EMBEDDINGS_FILE,
+    RECOMMENDED_MODELS,
+)
+
+console = Console()
+err_console = Console(stderr=True)
+
+config_app = typer.Typer()
+
+
+@config_app.command("embedding")
+def config_embedding(
+    model: Optional[str] = typer.Option(None, "--model", help="Set the embedding model."),
+    list_models: bool = typer.Option(False, "--list", help="Show recommended models."),
+    reset: bool = typer.Option(False, "--reset", help="Reset to the default model."),
+    as_json: bool = typer.Option(False, "--json", help="Output as JSON."),
+):
+    """Show or change the embedding model used for semantic search."""
+    if is_lens_mode():
+        err_console.print(
+            "[red]Error:[/red] 'config embedding' is not available in lens mode.\n"
+            "Configuration must be managed on the remote lattice server."
+        )
+        raise typer.Exit(1)
+
+    root = find_lattice_root()
+    if root is None:
+        err_console.print("[red]Error:[/red] No .lattice/ directory found.")
+        raise typer.Exit(1)
+
+    config = load_config(root)
+    current_model = config.get("embedding", {}).get("model", DEFAULT_MODEL)
+
+    # --list: show recommended models
+    if list_models:
+        _show_recommended_models(current_model, as_json)
+        return
+
+    # --reset: revert to default
+    if reset:
+        _set_embedding_model(root, config, current_model, DEFAULT_MODEL, as_json)
+        return
+
+    # --model: switch model
+    if model:
+        _set_embedding_model(root, config, current_model, model, as_json)
+        return
+
+    # No flags: show current model
+    if as_json:
+        import json
+
+        print(json.dumps({"model": current_model, "default": DEFAULT_MODEL}, indent=2))
+    else:
+        console.print(f"[bold]Embedding model:[/bold] {current_model}")
+        if current_model == DEFAULT_MODEL:
+            console.print("[dim]Using default model.[/dim]")
+        else:
+            console.print(f"[dim]Default: {DEFAULT_MODEL}[/dim]")
+        console.print("\n[dim]Use --list to see recommended models, --model to change.[/dim]")
+
+
+def _show_recommended_models(current_model: str, as_json: bool) -> None:
+    """Display the curated table of recommended embedding models."""
+    if as_json:
+        import json
+
+        data = {
+            "current": current_model,
+            "default": DEFAULT_MODEL,
+            "models": RECOMMENDED_MODELS,
+        }
+        print(json.dumps(data, indent=2))
+        return
+
+    console.print("\n[bold]Recommended Embedding Models:[/bold]\n")
+
+    table = Table(show_header=True)
+    table.add_column("Model", width=40)
+    table.add_column("Dims", justify="right", width=6)
+    table.add_column("Size", width=8)
+    table.add_column("Quality", width=8)
+    table.add_column("Speed", width=8)
+
+    for m in RECOMMENDED_MODELS:
+        name = m["name"]
+        if name == DEFAULT_MODEL:
+            name += " (default)"
+        style = "bold" if m["name"] == current_model else None
+        table.add_row(name, str(m["dims"]), m["size"], m["quality"], m["speed"], style=style)
+
+    console.print(table)
+    console.print(f"\n[bold]Current:[/bold] {current_model}")
+
+
+def _set_embedding_model(
+    root, config: dict, current_model: str, new_model: str, as_json: bool
+) -> None:
+    """Update the embedding model in config and clean up old embeddings."""
+    if new_model == current_model:
+        if as_json:
+            import json
+
+            print(json.dumps({"changed": False, "model": current_model}, indent=2))
+        else:
+            console.print(f"Already using model [bold]{current_model}[/bold]. Nothing to change.")
+        return
+
+    # Update config
+    if "embedding" not in config:
+        config["embedding"] = {}
+    config["embedding"]["model"] = new_model
+    save_config(root, config)
+
+    # Delete old embeddings (incompatible with new model)
+    embeddings_path = root / EMBEDDINGS_FILE
+    deleted_embeddings = False
+    if embeddings_path.exists():
+        embeddings_path.unlink()
+        deleted_embeddings = True
+
+    if as_json:
+        import json
+
+        print(
+            json.dumps(
+                {
+                    "changed": True,
+                    "previous_model": current_model,
+                    "model": new_model,
+                    "embeddings_deleted": deleted_embeddings,
+                },
+                indent=2,
+            )
+        )
+    else:
+        console.print(f"[green]Embedding model changed:[/green] {current_model} -> {new_model}")
+        if deleted_embeddings:
+            console.print("[yellow]Old embeddings deleted (incompatible with new model).[/yellow]")
+        console.print("[dim]Embedding model changed. Index will rebuild on next search.[/dim]")

--- a/src/lattice_lens/cli/main.py
+++ b/src/lattice_lens/cli/main.py
@@ -16,6 +16,7 @@ from lattice_lens.cli.graph_commands import graph_app
 from lattice_lens.cli.init_command import init
 from lattice_lens.cli.lens_commands import lens_app
 from lattice_lens.cli.reconcile_command import reconcile_cmd
+from lattice_lens.cli.search_command import search
 from lattice_lens.cli.seed_command import seed
 from lattice_lens.cli.serve_command import serve
 from lattice_lens.cli.status_command import status
@@ -53,6 +54,7 @@ app.command()(serve)
 app.command()(tags)
 app.command()(types)
 app.command("reconcile")(reconcile_cmd)
+app.command()(search)
 app.command()(view)
 
 

--- a/src/lattice_lens/cli/main.py
+++ b/src/lattice_lens/cli/main.py
@@ -6,6 +6,7 @@ import typer
 
 from lattice_lens.cli.backend_command import backend_app
 from lattice_lens.cli.check_command import check
+from lattice_lens.cli.config_command import config_app
 from lattice_lens.cli.context_commands import context
 from lattice_lens.cli.evaluate_command import evaluate
 from lattice_lens.cli.exchange_commands import export_cmd, import_cmd
@@ -35,6 +36,7 @@ app = typer.Typer(
 app.add_typer(fact_app, name="fact", help="Manage facts (add, get, ls, edit, promote, deprecate).")
 app.add_typer(graph_app, name="graph", help="Knowledge graph analysis.")
 app.add_typer(backend_app, name="backend", help="Backend management (status, switch).")
+app.add_typer(config_app, name="config", help="Configuration management.")
 app.add_typer(lens_app, name="lens", help="Remote lattice via MCP lens.")
 app.command()(init)
 app.command()(check)

--- a/src/lattice_lens/cli/search_command.py
+++ b/src/lattice_lens/cli/search_command.py
@@ -1,0 +1,141 @@
+"""lattice search — semantic similarity search for facts."""
+
+from __future__ import annotations
+
+import json
+from typing import Optional
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from lattice_lens.cli.helpers import require_lattice
+
+console = Console()
+err_console = Console(stderr=True)
+
+
+def search(
+    query: Optional[str] = typer.Argument(None, help="Natural language query for semantic search"),
+    tag: Optional[str] = typer.Option(None, "--tag", help="Filter results by tag"),
+    layer: Optional[str] = typer.Option(
+        None, "--layer", help="Filter results by layer (WHY/GUARDRAILS/HOW)"
+    ),
+    status: Optional[str] = typer.Option(None, "--status", help="Filter results by status"),
+    project: Optional[str] = typer.Option(None, "--project", help="Filter results by project"),
+    top: int = typer.Option(10, "--top", help="Number of results to return"),
+    threshold: float = typer.Option(0.3, "--threshold", help="Minimum similarity score (0-1)"),
+    rebuild_index: bool = typer.Option(
+        False, "--rebuild-index", help="Force rebuild the embedding index"
+    ),
+    as_json: bool = typer.Option(False, "--json", help="Output as JSON"),
+):
+    """Semantic search across lattice facts using embeddings."""
+    try:
+        from lattice_lens.services.embedding_service import (
+            HAS_SENTENCE_TRANSFORMERS,
+            semantic_search,
+        )
+    except Exception:
+        err_console.print(
+            "[red]Error:[/red] Failed to load embedding service. "
+            "Install with: [bold]pip install lattice-lens\\[semantic][/bold]"
+        )
+        raise typer.Exit(1)
+
+    if not HAS_SENTENCE_TRANSFORMERS:
+        err_console.print(
+            "[red]Error:[/red] sentence-transformers is not installed. "
+            "Install with: [bold]pip install lattice-lens\\[semantic][/bold]"
+        )
+        raise typer.Exit(1)
+
+    if not query and not rebuild_index:
+        err_console.print("[red]Error:[/red] Provide a search query or use --rebuild-index.")
+        raise typer.Exit(1)
+
+    store = require_lattice()
+
+    # Get all facts (all statuses for indexing, filter in search)
+    all_facts = store.list_facts(
+        status=["Active", "Under Review", "Draft", "Deprecated", "Superseded"]
+    )
+
+    if not all_facts:
+        err_console.print("[yellow]No facts found in lattice.[/yellow]")
+        raise typer.Exit(1)
+
+    lattice_root = store.root
+
+    if rebuild_index and not query:
+        # Just rebuild, no search
+        from lattice_lens.services.embedding_service import EmbeddingIndex, EMBEDDINGS_FILE
+
+        idx = EmbeddingIndex()
+        idx.build_index(all_facts)
+        idx.save(lattice_root / EMBEDDINGS_FILE)
+
+        if as_json:
+            print(
+                json.dumps(
+                    {
+                        "action": "rebuild",
+                        "facts_indexed": len(all_facts),
+                        "path": str(lattice_root / EMBEDDINGS_FILE),
+                    },
+                    indent=2,
+                )
+            )
+        else:
+            console.print(
+                f"[green]Rebuilt embedding index:[/green] {len(all_facts)} facts indexed."
+            )
+        return
+
+    results = semantic_search(
+        facts=all_facts,
+        query=query,
+        lattice_root=lattice_root,
+        top_k=top,
+        threshold=threshold,
+        force_rebuild=rebuild_index,
+        tag=tag,
+        layer=layer,
+        status=status,
+        project=project,
+    )
+
+    if as_json:
+        print(json.dumps({"query": query, "results": results}, indent=2))
+        return
+
+    if not results:
+        console.print(f"[dim]No facts matched query '{query}' above threshold {threshold}.[/dim]")
+        return
+
+    console.print(f'\n[bold]Semantic search:[/bold] "{query}"')
+    console.print(f"[dim]Showing top {len(results)} results (threshold >= {threshold})[/dim]\n")
+
+    table = Table(show_header=True)
+    table.add_column("Score", style="bold cyan", justify="right", width=7)
+    table.add_column("Code", style="bold", width=8)
+    table.add_column("Type", width=30)
+    table.add_column("Layer", width=12)
+    table.add_column("Tags", width=20)
+    table.add_column("Snippet", width=50)
+
+    for r in results:
+        score_str = f"{r['score']:.3f}"
+        tags_str = ", ".join(r["tags"][:3])
+        if len(r["tags"]) > 3:
+            tags_str += "..."
+        table.add_row(
+            score_str,
+            r["code"],
+            r["type"],
+            r["layer"],
+            tags_str,
+            r["snippet"][:80] + ("..." if len(r["snippet"]) > 80 else ""),
+        )
+
+    console.print(table)

--- a/src/lattice_lens/services/embedding_service.py
+++ b/src/lattice_lens/services/embedding_service.py
@@ -1,0 +1,321 @@
+"""Semantic embedding and similarity search for lattice facts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from lattice_lens.models import Fact
+
+try:
+    import numpy as np
+    from sentence_transformers import SentenceTransformer
+
+    HAS_SENTENCE_TRANSFORMERS = True
+except ImportError:
+    HAS_SENTENCE_TRANSFORMERS = False
+    np = None  # type: ignore[assignment]
+    SentenceTransformer = None  # type: ignore[assignment,misc]
+
+try:
+    import faiss
+
+    HAS_FAISS = True
+except ImportError:
+    HAS_FAISS = False
+
+EMBEDDINGS_FILE = "embeddings.json"
+DEFAULT_MODEL = "all-MiniLM-L6-v2"
+DEFAULT_TOP_K = 10
+DEFAULT_THRESHOLD = 0.3
+
+
+def _fact_text(fact: Fact) -> str:
+    """Build the text to embed for a fact: title + body."""
+    # 'type' serves as the title/category, 'fact' is the body
+    return f"{fact.type}. {fact.fact}"
+
+
+def _fact_checksum(fact: Fact) -> str:
+    """Compute a content checksum for staleness detection."""
+    content = f"{fact.type}|{fact.fact}|{fact.version}"
+    return hashlib.sha256(content.encode()).hexdigest()[:16]
+
+
+def _cosine_similarity(query_vec: "np.ndarray", matrix: "np.ndarray") -> "np.ndarray":
+    """Compute cosine similarity between a query vector and a matrix of vectors."""
+    # Normalize
+    query_norm = query_vec / (np.linalg.norm(query_vec) + 1e-10)
+    norms = np.linalg.norm(matrix, axis=1, keepdims=True) + 1e-10
+    matrix_norm = matrix / norms
+    return matrix_norm @ query_norm
+
+
+class EmbeddingIndex:
+    """Manages fact embeddings and similarity search."""
+
+    def __init__(self, model_name: str = DEFAULT_MODEL):
+        if not HAS_SENTENCE_TRANSFORMERS:
+            raise ImportError(
+                "sentence-transformers is required for semantic search. "
+                "Install with: pip install lattice-lens[semantic]"
+            )
+        self._model_name = model_name
+        self._model: SentenceTransformer | None = None
+        self._embeddings: np.ndarray | None = None
+        self._fact_codes: list[str] = []
+        self._checksums: dict[str, str] = {}
+        self._built_at: str | None = None
+        self._faiss_index = None
+
+    @property
+    def model(self) -> SentenceTransformer:
+        if self._model is None:
+            self._model = SentenceTransformer(self._model_name)
+        return self._model
+
+    @property
+    def fact_codes(self) -> list[str]:
+        return list(self._fact_codes)
+
+    @property
+    def fact_count(self) -> int:
+        return len(self._fact_codes)
+
+    def build_index(self, facts: list[Fact]) -> None:
+        """Embed all facts and build the search index."""
+        if not facts:
+            self._embeddings = np.zeros((0, 0))
+            self._fact_codes = []
+            self._checksums = {}
+            self._built_at = datetime.now(timezone.utc).isoformat()
+            return
+
+        texts = [_fact_text(f) for f in facts]
+        embeddings = self.model.encode(texts, show_progress_bar=False)
+        self._embeddings = np.array(embeddings, dtype=np.float32)
+        self._fact_codes = [f.code for f in facts]
+        self._checksums = {f.code: _fact_checksum(f) for f in facts}
+        self._built_at = datetime.now(timezone.utc).isoformat()
+
+        # Build FAISS index if available
+        self._faiss_index = None
+        if HAS_FAISS and len(facts) > 0:
+            dim = self._embeddings.shape[1]
+            self._faiss_index = faiss.IndexFlatIP(dim)
+            # Normalize for cosine similarity via inner product
+            norms = np.linalg.norm(self._embeddings, axis=1, keepdims=True) + 1e-10
+            normalized = self._embeddings / norms
+            self._faiss_index.add(normalized)
+
+    def search(
+        self,
+        query: str,
+        top_k: int = DEFAULT_TOP_K,
+        threshold: float = DEFAULT_THRESHOLD,
+    ) -> list[tuple[str, float]]:
+        """Semantic search: find facts similar to query.
+
+        Returns list of (fact_code, similarity_score) tuples, sorted by score descending.
+        """
+        if self._embeddings is None or len(self._fact_codes) == 0:
+            return []
+
+        query_embedding = self.model.encode([query], show_progress_bar=False)
+        query_vec = np.array(query_embedding, dtype=np.float32)[0]
+
+        if self._faiss_index is not None:
+            # FAISS path — normalized inner product = cosine similarity
+            query_norm = query_vec / (np.linalg.norm(query_vec) + 1e-10)
+            scores, indices = self._faiss_index.search(
+                query_norm.reshape(1, -1), min(top_k, len(self._fact_codes))
+            )
+            results = []
+            for score, idx in zip(scores[0], indices[0]):
+                if idx < 0:
+                    continue
+                if score >= threshold:
+                    results.append((self._fact_codes[idx], float(score)))
+            return results
+        else:
+            # NumPy fallback
+            scores = _cosine_similarity(query_vec, self._embeddings)
+            ranked_indices = np.argsort(scores)[::-1][:top_k]
+            results = []
+            for idx in ranked_indices:
+                score = float(scores[idx])
+                if score >= threshold:
+                    results.append((self._fact_codes[idx], score))
+            return results
+
+    def save(self, path: str | Path) -> None:
+        """Save embeddings to .lattice/embeddings.json."""
+        if self._embeddings is None:
+            return
+
+        data = {
+            "model": self._model_name,
+            "built_at": self._built_at,
+            "fact_count": len(self._fact_codes),
+            "fact_codes": self._fact_codes,
+            "checksums": self._checksums,
+            "embeddings": {
+                code: emb.tolist() for code, emb in zip(self._fact_codes, self._embeddings)
+            },
+        }
+
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "w") as f:
+            json.dump(data, f)
+
+    def load(self, path: str | Path) -> bool:
+        """Load saved embeddings. Returns False if missing or corrupt."""
+        path = Path(path)
+        if not path.exists():
+            return False
+
+        try:
+            with open(path) as f:
+                data = json.load(f)
+        except (json.JSONDecodeError, OSError):
+            return False
+
+        if data.get("model") != self._model_name:
+            return False
+
+        fact_codes = data.get("fact_codes", [])
+        embeddings_dict = data.get("embeddings", {})
+
+        if not fact_codes or not embeddings_dict:
+            return False
+
+        # Reconstruct numpy matrix in code order
+        try:
+            matrix = np.array([embeddings_dict[code] for code in fact_codes], dtype=np.float32)
+        except (KeyError, ValueError):
+            return False
+
+        self._fact_codes = fact_codes
+        self._checksums = data.get("checksums", {})
+        self._built_at = data.get("built_at")
+        self._embeddings = matrix
+
+        # Rebuild FAISS index if available
+        self._faiss_index = None
+        if HAS_FAISS and len(self._fact_codes) > 0:
+            dim = self._embeddings.shape[1]
+            self._faiss_index = faiss.IndexFlatIP(dim)
+            norms = np.linalg.norm(self._embeddings, axis=1, keepdims=True) + 1e-10
+            normalized = self._embeddings / norms
+            self._faiss_index.add(normalized)
+
+        return True
+
+    def is_stale(self, facts: list[Fact]) -> bool:
+        """Check if index needs rebuilding (new/changed facts)."""
+        if self._embeddings is None:
+            return True
+
+        current_codes = {f.code for f in facts}
+        indexed_codes = set(self._fact_codes)
+
+        # New or removed facts
+        if current_codes != indexed_codes:
+            return True
+
+        # Changed content
+        for fact in facts:
+            stored = self._checksums.get(fact.code)
+            if stored is None or stored != _fact_checksum(fact):
+                return True
+
+        return False
+
+
+def semantic_search(
+    facts: list[Fact],
+    query: str,
+    lattice_root: Path | None = None,
+    model_name: str = DEFAULT_MODEL,
+    top_k: int = DEFAULT_TOP_K,
+    threshold: float = DEFAULT_THRESHOLD,
+    force_rebuild: bool = False,
+    tag: str | None = None,
+    layer: str | None = None,
+    status: str | None = None,
+    project: str | None = None,
+) -> list[dict]:
+    """High-level semantic search function.
+
+    Loads or builds the embedding index, searches, applies post-filters,
+    and returns enriched results.
+    """
+    if not HAS_SENTENCE_TRANSFORMERS:
+        raise ImportError(
+            "sentence-transformers is required for semantic search. "
+            "Install with: pip install lattice-lens[semantic]"
+        )
+
+    index = EmbeddingIndex(model_name=model_name)
+
+    # Try loading cached embeddings
+    embeddings_path = lattice_root / EMBEDDINGS_FILE if lattice_root else None
+    loaded = False
+    if embeddings_path and not force_rebuild:
+        loaded = index.load(embeddings_path)
+
+    # Rebuild if stale or not loaded
+    if not loaded or force_rebuild or index.is_stale(facts):
+        index.build_index(facts)
+        if embeddings_path:
+            index.save(embeddings_path)
+
+    # Search
+    raw_results = index.search(query, top_k=top_k * 3, threshold=threshold)
+
+    # Build fact lookup
+    fact_map = {f.code: f for f in facts}
+
+    # Apply post-filters and enrich
+    results = []
+    for code, score in raw_results:
+        fact = fact_map.get(code)
+        if fact is None:
+            continue
+
+        if tag and tag.lower() not in fact.tags:
+            continue
+        if layer and fact.layer.value != layer:
+            continue
+        if status and fact.status.value != status:
+            continue
+        if project and project.lower() not in [p.lower() for p in fact.projects]:
+            continue
+
+        # Snippet: first 150 chars of fact text
+        snippet = fact.fact[:150]
+        if len(fact.fact) > 150:
+            snippet += "..."
+
+        results.append(
+            {
+                "code": fact.code,
+                "type": fact.type,
+                "score": round(score, 4),
+                "layer": fact.layer.value,
+                "status": fact.status.value,
+                "tags": fact.tags,
+                "projects": fact.projects,
+                "snippet": snippet,
+            }
+        )
+
+        if len(results) >= top_k:
+            break
+
+    return results

--- a/src/lattice_lens/services/embedding_service.py
+++ b/src/lattice_lens/services/embedding_service.py
@@ -33,6 +33,61 @@ DEFAULT_MODEL = "all-MiniLM-L6-v2"
 DEFAULT_TOP_K = 10
 DEFAULT_THRESHOLD = 0.3
 
+RECOMMENDED_MODELS: list[dict[str, str | int]] = [
+    {
+        "name": "all-MiniLM-L6-v2",
+        "dims": 384,
+        "size": "80MB",
+        "quality": "Good",
+        "speed": "Fast",
+    },
+    {
+        "name": "BAAI/bge-small-en-v1.5",
+        "dims": 384,
+        "size": "130MB",
+        "quality": "Better",
+        "speed": "Fast",
+    },
+    {
+        "name": "all-mpnet-base-v2",
+        "dims": 768,
+        "size": "420MB",
+        "quality": "Best",
+        "speed": "Medium",
+    },
+    {
+        "name": "nomic-ai/nomic-embed-text-v1.5",
+        "dims": 768,
+        "size": "550MB",
+        "quality": "Best",
+        "speed": "Medium",
+    },
+    {
+        "name": "Snowflake/snowflake-arctic-embed-s",
+        "dims": 384,
+        "size": "130MB",
+        "quality": "Better",
+        "speed": "Fast",
+    },
+]
+
+
+def get_embedding_model(lattice_root: Path) -> str:
+    """Read embedding model from .lattice/config.yaml, default to MiniLM."""
+    config_path = lattice_root / "config.yaml"
+    if config_path.exists():
+        try:
+            from ruamel.yaml import YAML
+
+            yaml = YAML()
+            with open(config_path) as f:
+                config = yaml.load(f)
+            if config:
+                return config.get("embedding", {}).get("model", DEFAULT_MODEL)
+        except Exception:
+            pass
+    return DEFAULT_MODEL
+
 
 def _fact_text(fact: Fact) -> str:
     """Build the text to embed for a fact: title + body."""
@@ -241,7 +296,7 @@ def semantic_search(
     facts: list[Fact],
     query: str,
     lattice_root: Path | None = None,
-    model_name: str = DEFAULT_MODEL,
+    model_name: str | None = None,
     top_k: int = DEFAULT_TOP_K,
     threshold: float = DEFAULT_THRESHOLD,
     force_rebuild: bool = False,
@@ -254,12 +309,21 @@ def semantic_search(
 
     Loads or builds the embedding index, searches, applies post-filters,
     and returns enriched results.
+
+    When model_name is None, reads the configured model from .lattice/config.yaml.
     """
     if not HAS_SENTENCE_TRANSFORMERS:
         raise ImportError(
             "sentence-transformers is required for semantic search. "
             "Install with: pip install lattice-lens[semantic]"
         )
+
+    # Resolve model: explicit argument > config file > default
+    if model_name is None:
+        if lattice_root is not None:
+            model_name = get_embedding_model(lattice_root)
+        else:
+            model_name = DEFAULT_MODEL
 
     index = EmbeddingIndex(model_name=model_name)
 

--- a/tests/test_embedding_config.py
+++ b/tests/test_embedding_config.py
@@ -1,0 +1,274 @@
+"""Tests for configurable embedding model feature."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from ruamel.yaml import YAML
+from typer.testing import CliRunner
+
+from lattice_lens.cli.main import app
+from lattice_lens.config import FACTS_DIR, HISTORY_DIR, LATTICE_DIR, ROLES_DIR, load_config
+from lattice_lens.services.embedding_service import (
+    DEFAULT_MODEL,
+    EMBEDDINGS_FILE,
+    RECOMMENDED_MODELS,
+    get_embedding_model,
+)
+
+runner = CliRunner()
+yaml_rw = YAML()
+yaml_rw.default_flow_style = False
+
+
+@pytest.fixture
+def lattice_dir(tmp_path: Path) -> Path:
+    """Create a minimal .lattice/ directory with config.yaml."""
+    lattice_root = tmp_path / LATTICE_DIR
+    (lattice_root / FACTS_DIR).mkdir(parents=True)
+    (lattice_root / ROLES_DIR).mkdir(parents=True)
+    (lattice_root / HISTORY_DIR).mkdir(parents=True)
+
+    config = {"version": "0.7.0", "backend": "yaml"}
+    config_path = lattice_root / "config.yaml"
+    with open(config_path, "w") as f:
+        yaml_rw.dump(config, f)
+
+    return lattice_root
+
+
+# --- get_embedding_model tests ---
+
+
+class TestGetEmbeddingModel:
+    def test_default_when_no_config(self, tmp_path: Path):
+        """Returns default model when config.yaml doesn't exist."""
+        lattice_root = tmp_path / ".lattice"
+        lattice_root.mkdir()
+        assert get_embedding_model(lattice_root) == DEFAULT_MODEL
+
+    def test_default_when_no_embedding_section(self, lattice_dir: Path):
+        """Returns default model when embedding section is missing."""
+        assert get_embedding_model(lattice_dir) == DEFAULT_MODEL
+
+    def test_reads_configured_model(self, lattice_dir: Path):
+        """Returns the model specified in config."""
+        config = load_config(lattice_dir)
+        config["embedding"] = {"model": "BAAI/bge-small-en-v1.5"}
+        from lattice_lens.config import save_config
+
+        save_config(lattice_dir, config)
+
+        assert get_embedding_model(lattice_dir) == "BAAI/bge-small-en-v1.5"
+
+    def test_default_when_empty_embedding_section(self, lattice_dir: Path):
+        """Returns default when embedding section exists but model key is missing."""
+        config = load_config(lattice_dir)
+        config["embedding"] = {}
+        from lattice_lens.config import save_config
+
+        save_config(lattice_dir, config)
+
+        assert get_embedding_model(lattice_dir) == DEFAULT_MODEL
+
+
+# --- CLI config embedding tests ---
+
+
+class TestConfigEmbeddingCLI:
+    def test_show_current_model_default(self, lattice_dir: Path, monkeypatch):
+        """Shows default model when nothing configured."""
+        monkeypatch.chdir(lattice_dir.parent)
+
+        result = runner.invoke(app, ["config", "embedding"])
+        assert result.exit_code == 0
+        assert DEFAULT_MODEL in result.output
+        assert "default" in result.output.lower()
+
+    def test_show_current_model_custom(self, lattice_dir: Path, monkeypatch):
+        """Shows custom model when configured."""
+        monkeypatch.chdir(lattice_dir.parent)
+
+        config = load_config(lattice_dir)
+        config["embedding"] = {"model": "all-mpnet-base-v2"}
+        from lattice_lens.config import save_config
+
+        save_config(lattice_dir, config)
+
+        result = runner.invoke(app, ["config", "embedding"])
+        assert result.exit_code == 0
+        assert "all-mpnet-base-v2" in result.output
+
+    def test_show_current_model_json(self, lattice_dir: Path, monkeypatch):
+        """JSON output for current model."""
+        monkeypatch.chdir(lattice_dir.parent)
+
+        result = runner.invoke(app, ["config", "embedding", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["model"] == DEFAULT_MODEL
+        assert data["default"] == DEFAULT_MODEL
+
+    def test_list_models(self, lattice_dir: Path, monkeypatch):
+        """--list shows recommended models table."""
+        monkeypatch.chdir(lattice_dir.parent)
+
+        result = runner.invoke(app, ["config", "embedding", "--list"])
+        assert result.exit_code == 0
+        assert "Recommended" in result.output
+        for m in RECOMMENDED_MODELS:
+            assert m["name"] in result.output
+
+    def test_list_models_json(self, lattice_dir: Path, monkeypatch):
+        """--list --json outputs structured model list."""
+        monkeypatch.chdir(lattice_dir.parent)
+
+        result = runner.invoke(app, ["config", "embedding", "--list", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert "models" in data
+        assert len(data["models"]) == len(RECOMMENDED_MODELS)
+        assert data["current"] == DEFAULT_MODEL
+
+    def test_set_model(self, lattice_dir: Path, monkeypatch):
+        """--model changes the embedding model in config."""
+        monkeypatch.chdir(lattice_dir.parent)
+
+        result = runner.invoke(app, ["config", "embedding", "--model", "BAAI/bge-small-en-v1.5"])
+        assert result.exit_code == 0
+        assert "BAAI/bge-small-en-v1.5" in result.output
+
+        # Verify config was updated
+        config = load_config(lattice_dir)
+        assert config["embedding"]["model"] == "BAAI/bge-small-en-v1.5"
+
+    def test_set_model_deletes_old_embeddings(self, lattice_dir: Path, monkeypatch):
+        """Changing model deletes existing embeddings.json."""
+        monkeypatch.chdir(lattice_dir.parent)
+
+        # Create a fake embeddings file
+        embeddings_path = lattice_dir / EMBEDDINGS_FILE
+        embeddings_path.write_text('{"model": "all-MiniLM-L6-v2", "fact_codes": []}')
+        assert embeddings_path.exists()
+
+        result = runner.invoke(app, ["config", "embedding", "--model", "all-mpnet-base-v2"])
+        assert result.exit_code == 0
+
+        # Embeddings file should be deleted
+        assert not embeddings_path.exists()
+        assert "deleted" in result.output.lower() or "incompatible" in result.output.lower()
+
+    def test_set_model_no_change(self, lattice_dir: Path, monkeypatch):
+        """Setting same model is a no-op."""
+        monkeypatch.chdir(lattice_dir.parent)
+
+        result = runner.invoke(app, ["config", "embedding", "--model", DEFAULT_MODEL])
+        assert result.exit_code == 0
+        assert "Already" in result.output or "Nothing" in result.output
+
+    def test_set_model_json(self, lattice_dir: Path, monkeypatch):
+        """--model --json returns structured output."""
+        monkeypatch.chdir(lattice_dir.parent)
+
+        result = runner.invoke(
+            app, ["config", "embedding", "--model", "all-mpnet-base-v2", "--json"]
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["changed"] is True
+        assert data["model"] == "all-mpnet-base-v2"
+        assert data["previous_model"] == DEFAULT_MODEL
+
+    def test_reset_model(self, lattice_dir: Path, monkeypatch):
+        """--reset reverts to default model."""
+        monkeypatch.chdir(lattice_dir.parent)
+
+        # First set a non-default model
+        config = load_config(lattice_dir)
+        config["embedding"] = {"model": "all-mpnet-base-v2"}
+        from lattice_lens.config import save_config
+
+        save_config(lattice_dir, config)
+
+        result = runner.invoke(app, ["config", "embedding", "--reset"])
+        assert result.exit_code == 0
+
+        config = load_config(lattice_dir)
+        assert config["embedding"]["model"] == DEFAULT_MODEL
+
+    def test_reset_when_already_default(self, lattice_dir: Path, monkeypatch):
+        """--reset when already default is a no-op."""
+        monkeypatch.chdir(lattice_dir.parent)
+
+        result = runner.invoke(app, ["config", "embedding", "--reset"])
+        assert result.exit_code == 0
+        assert "Already" in result.output or "Nothing" in result.output
+
+
+# --- Staleness detection with model change ---
+
+
+class TestModelStaleness:
+    def test_load_rejects_different_model(self, lattice_dir: Path):
+        """EmbeddingIndex.load returns False when cached model doesn't match."""
+        from lattice_lens.services.embedding_service import EmbeddingIndex
+
+        # Create a fake embeddings file with model A
+        embeddings_path = lattice_dir / EMBEDDINGS_FILE
+        data = {
+            "model": "all-MiniLM-L6-v2",
+            "built_at": "2024-01-01T00:00:00+00:00",
+            "fact_count": 1,
+            "fact_codes": ["ADR-01"],
+            "checksums": {"ADR-01": "abc123"},
+            "embeddings": {"ADR-01": [0.1] * 384},
+        }
+        with open(embeddings_path, "w") as f:
+            json.dump(data, f)
+
+        # Try to load with model B
+        index = EmbeddingIndex(model_name="all-mpnet-base-v2")
+        loaded = index.load(embeddings_path)
+        assert loaded is False
+
+    def test_load_accepts_same_model(self, lattice_dir: Path):
+        """EmbeddingIndex.load returns True when cached model matches."""
+        from lattice_lens.services.embedding_service import EmbeddingIndex
+
+        embeddings_path = lattice_dir / EMBEDDINGS_FILE
+        data = {
+            "model": "all-MiniLM-L6-v2",
+            "built_at": "2024-01-01T00:00:00+00:00",
+            "fact_count": 1,
+            "fact_codes": ["ADR-01"],
+            "checksums": {"ADR-01": "abc123"},
+            "embeddings": {"ADR-01": [0.1] * 384},
+        }
+        with open(embeddings_path, "w") as f:
+            json.dump(data, f)
+
+        index = EmbeddingIndex(model_name="all-MiniLM-L6-v2")
+        loaded = index.load(embeddings_path)
+        assert loaded is True
+
+
+# --- RECOMMENDED_MODELS data integrity ---
+
+
+class TestRecommendedModels:
+    def test_default_model_in_list(self):
+        """Default model must be in the recommended list."""
+        names = [m["name"] for m in RECOMMENDED_MODELS]
+        assert DEFAULT_MODEL in names
+
+    def test_all_models_have_required_fields(self):
+        """Each recommended model has name, dims, size, quality, speed."""
+        required = {"name", "dims", "size", "quality", "speed"}
+        for m in RECOMMENDED_MODELS:
+            assert required.issubset(m.keys()), f"Missing fields in {m}"
+
+    def test_at_least_three_models(self):
+        """We should offer meaningful choice."""
+        assert len(RECOMMENDED_MODELS) >= 3

--- a/tests/test_semantic_search.py
+++ b/tests/test_semantic_search.py
@@ -1,0 +1,564 @@
+"""Tests for semantic search — embedding service and CLI."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from lattice_lens.models import FactLayer, FactStatus
+from tests.conftest import make_fact
+
+
+# ---------------------------------------------------------------------------
+# Unit tests that do NOT require sentence-transformers
+# ---------------------------------------------------------------------------
+
+
+class TestGracefulDegradation:
+    """Verify graceful errors when sentence-transformers is not installed."""
+
+    def test_import_service_always_works(self):
+        """The module should import without error regardless of dependencies."""
+        from lattice_lens.services import embedding_service
+
+        assert hasattr(embedding_service, "EmbeddingIndex")
+        assert hasattr(embedding_service, "semantic_search")
+        assert hasattr(embedding_service, "HAS_SENTENCE_TRANSFORMERS")
+
+    def test_has_sentence_transformers_flag(self):
+        """Flag should be a boolean."""
+        from lattice_lens.services.embedding_service import HAS_SENTENCE_TRANSFORMERS
+
+        assert isinstance(HAS_SENTENCE_TRANSFORMERS, bool)
+
+
+class TestFactChecksum:
+    """Test the checksum utility (no ML dependencies needed)."""
+
+    def test_checksum_deterministic(self):
+        from lattice_lens.services.embedding_service import _fact_checksum
+
+        fact = make_fact(code="ADR-01", fact="This is a test fact with sufficient text.")
+        c1 = _fact_checksum(fact)
+        c2 = _fact_checksum(fact)
+        assert c1 == c2
+
+    def test_checksum_changes_with_content(self):
+        from lattice_lens.services.embedding_service import _fact_checksum
+
+        fact1 = make_fact(code="ADR-01", fact="This is a test fact with sufficient text.")
+        fact2 = make_fact(code="ADR-01", fact="Different fact text that is long enough.")
+        assert _fact_checksum(fact1) != _fact_checksum(fact2)
+
+    def test_checksum_changes_with_version(self):
+        from lattice_lens.services.embedding_service import _fact_checksum
+
+        fact1 = make_fact(
+            code="ADR-01", fact="This is a test fact with sufficient text.", version=1
+        )
+        fact2 = make_fact(
+            code="ADR-01", fact="This is a test fact with sufficient text.", version=2
+        )
+        assert _fact_checksum(fact1) != _fact_checksum(fact2)
+
+
+class TestFactText:
+    """Test the text generation utility."""
+
+    def test_fact_text_combines_type_and_body(self):
+        from lattice_lens.services.embedding_service import _fact_text
+
+        fact = make_fact(
+            type="Architecture Decision Record",
+            fact="We decided to use PostgreSQL as the primary database.",
+        )
+        text = _fact_text(fact)
+        assert "Architecture Decision Record" in text
+        assert "PostgreSQL" in text
+
+
+# ---------------------------------------------------------------------------
+# Integration tests that REQUIRE sentence-transformers
+# ---------------------------------------------------------------------------
+
+
+def _st_available():
+    try:
+        import sentence_transformers  # noqa: F401
+        import numpy  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+requires_st = pytest.mark.skipif(
+    not _st_available(),
+    reason="sentence-transformers not installed",
+)
+
+
+def _make_diverse_facts():
+    """Create a set of facts with diverse topics for semantic testing."""
+    return [
+        make_fact(
+            code="ADR-01",
+            layer=FactLayer.WHY,
+            type="Architecture Decision Record",
+            fact="We use PostgreSQL as the primary database for its reliability and JSONB support.",
+            tags=["database", "architecture"],
+            status=FactStatus.ACTIVE,
+        ),
+        make_fact(
+            code="ADR-02",
+            layer=FactLayer.WHY,
+            type="Architecture Decision Record",
+            fact="The deployment pipeline uses Docker containers orchestrated by Kubernetes.",
+            tags=["deployment", "infrastructure"],
+            status=FactStatus.ACTIVE,
+        ),
+        make_fact(
+            code="MC-01",
+            layer=FactLayer.GUARDRAILS,
+            type="Mandatory Control",
+            fact="All API endpoints must validate authentication tokens before processing requests.",
+            tags=["security", "api"],
+            status=FactStatus.ACTIVE,
+        ),
+        make_fact(
+            code="SP-01",
+            layer=FactLayer.HOW,
+            type="Standard Procedure",
+            fact="Unit tests must cover at least 80% of code. Use pytest for testing.",
+            tags=["testing", "quality"],
+            status=FactStatus.ACTIVE,
+        ),
+        make_fact(
+            code="RISK-01",
+            layer=FactLayer.GUARDRAILS,
+            type="Risk Register Entry",
+            fact="Data loss risk is mitigated by automated daily backups to S3.",
+            tags=["risk", "backup"],
+            status=FactStatus.ACTIVE,
+        ),
+        make_fact(
+            code="ADR-03",
+            layer=FactLayer.WHY,
+            type="Architecture Decision Record",
+            fact="We chose GraphQL over REST for the public API to reduce over-fetching.",
+            tags=["api", "architecture"],
+            status=FactStatus.ACTIVE,
+            projects=["backend"],
+        ),
+        make_fact(
+            code="DG-01",
+            layer=FactLayer.GUARDRAILS,
+            type="Data Governance Rule",
+            fact="Every mutation to the knowledge lattice must be appended to the changelog.",
+            tags=["governance", "changelog"],
+            status=FactStatus.ACTIVE,
+        ),
+    ]
+
+
+@requires_st
+class TestEmbeddingIndex:
+    """Test EmbeddingIndex with real embeddings."""
+
+    def test_build_index(self):
+        from lattice_lens.services.embedding_service import EmbeddingIndex
+
+        facts = _make_diverse_facts()
+        idx = EmbeddingIndex()
+        idx.build_index(facts)
+        assert idx.fact_count == len(facts)
+
+    def test_build_empty(self):
+        from lattice_lens.services.embedding_service import EmbeddingIndex
+
+        idx = EmbeddingIndex()
+        idx.build_index([])
+        assert idx.fact_count == 0
+
+    def test_search_returns_relevant_results(self):
+        from lattice_lens.services.embedding_service import EmbeddingIndex
+
+        facts = _make_diverse_facts()
+        idx = EmbeddingIndex()
+        idx.build_index(facts)
+
+        results = idx.search("database storage", top_k=3, threshold=0.1)
+        assert len(results) > 0
+        codes = [code for code, _score in results]
+        # ADR-01 (PostgreSQL/database) should be top result
+        assert "ADR-01" in codes[:2]
+
+    def test_search_deployment(self):
+        from lattice_lens.services.embedding_service import EmbeddingIndex
+
+        facts = _make_diverse_facts()
+        idx = EmbeddingIndex()
+        idx.build_index(facts)
+
+        results = idx.search("deployment pipeline containers", top_k=3, threshold=0.1)
+        assert len(results) > 0
+        codes = [code for code, _score in results]
+        assert "ADR-02" in codes[:2]
+
+    def test_search_security(self):
+        from lattice_lens.services.embedding_service import EmbeddingIndex
+
+        facts = _make_diverse_facts()
+        idx = EmbeddingIndex()
+        idx.build_index(facts)
+
+        results = idx.search("authentication security", top_k=3, threshold=0.1)
+        assert len(results) > 0
+        codes = [code for code, _score in results]
+        assert "MC-01" in codes[:2]
+
+    def test_search_empty_index(self):
+        from lattice_lens.services.embedding_service import EmbeddingIndex
+
+        idx = EmbeddingIndex()
+        idx.build_index([])
+        results = idx.search("anything")
+        assert results == []
+
+    def test_threshold_filtering(self):
+        from lattice_lens.services.embedding_service import EmbeddingIndex
+
+        facts = _make_diverse_facts()
+        idx = EmbeddingIndex()
+        idx.build_index(facts)
+
+        # Very high threshold should return fewer results
+        strict = idx.search("database", top_k=10, threshold=0.9)
+        loose = idx.search("database", top_k=10, threshold=0.1)
+        assert len(loose) >= len(strict)
+
+
+@requires_st
+class TestStalenessDetection:
+    """Test index staleness checks."""
+
+    def test_not_stale_when_same(self):
+        from lattice_lens.services.embedding_service import EmbeddingIndex
+
+        facts = _make_diverse_facts()
+        idx = EmbeddingIndex()
+        idx.build_index(facts)
+        assert not idx.is_stale(facts)
+
+    def test_stale_when_new_fact(self):
+        from lattice_lens.services.embedding_service import EmbeddingIndex
+
+        facts = _make_diverse_facts()
+        idx = EmbeddingIndex()
+        idx.build_index(facts)
+
+        new_fact = make_fact(
+            code="SP-02",
+            layer=FactLayer.HOW,
+            type="Standard Procedure",
+            fact="Logging must use structured JSON format for all services.",
+            tags=["logging", "observability"],
+        )
+        assert idx.is_stale(facts + [new_fact])
+
+    def test_stale_when_fact_removed(self):
+        from lattice_lens.services.embedding_service import EmbeddingIndex
+
+        facts = _make_diverse_facts()
+        idx = EmbeddingIndex()
+        idx.build_index(facts)
+        assert idx.is_stale(facts[:-1])
+
+    def test_stale_when_content_changed(self):
+        from lattice_lens.services.embedding_service import EmbeddingIndex
+
+        facts = _make_diverse_facts()
+        idx = EmbeddingIndex()
+        idx.build_index(facts)
+
+        modified = list(facts)
+        modified[0] = make_fact(
+            code="ADR-01",
+            layer=FactLayer.WHY,
+            type="Architecture Decision Record",
+            fact="We switched from PostgreSQL to MySQL for licensing reasons.",
+            tags=["database", "architecture"],
+            status=FactStatus.ACTIVE,
+        )
+        assert idx.is_stale(modified)
+
+    def test_stale_when_no_embeddings(self):
+        from lattice_lens.services.embedding_service import EmbeddingIndex
+
+        idx = EmbeddingIndex()
+        assert idx.is_stale(_make_diverse_facts())
+
+
+@requires_st
+class TestSaveLoad:
+    """Test save/load round-trip."""
+
+    def test_save_load_roundtrip(self, tmp_path):
+        from lattice_lens.services.embedding_service import EmbeddingIndex
+
+        facts = _make_diverse_facts()
+        idx = EmbeddingIndex()
+        idx.build_index(facts)
+
+        path = tmp_path / "embeddings.json"
+        idx.save(path)
+
+        # Load into fresh index
+        idx2 = EmbeddingIndex()
+        assert idx2.load(path)
+        assert idx2.fact_count == idx.fact_count
+        assert idx2.fact_codes == idx.fact_codes
+
+    def test_load_preserves_search(self, tmp_path):
+        from lattice_lens.services.embedding_service import EmbeddingIndex
+
+        facts = _make_diverse_facts()
+        idx = EmbeddingIndex()
+        idx.build_index(facts)
+
+        path = tmp_path / "embeddings.json"
+        idx.save(path)
+
+        idx2 = EmbeddingIndex()
+        idx2.load(path)
+
+        # Search should work on loaded index
+        results = idx2.search("database storage", top_k=3, threshold=0.1)
+        assert len(results) > 0
+        codes = [code for code, _ in results]
+        assert "ADR-01" in codes[:2]
+
+    def test_load_missing_file(self, tmp_path):
+        from lattice_lens.services.embedding_service import EmbeddingIndex
+
+        idx = EmbeddingIndex()
+        assert not idx.load(tmp_path / "nonexistent.json")
+
+    def test_load_corrupt_file(self, tmp_path):
+        from lattice_lens.services.embedding_service import EmbeddingIndex
+
+        path = tmp_path / "embeddings.json"
+        path.write_text("not valid json {{{")
+
+        idx = EmbeddingIndex()
+        assert not idx.load(path)
+
+    def test_load_wrong_model(self, tmp_path):
+        from lattice_lens.services.embedding_service import EmbeddingIndex
+
+        facts = _make_diverse_facts()
+        idx = EmbeddingIndex()
+        idx.build_index(facts)
+
+        path = tmp_path / "embeddings.json"
+        idx.save(path)
+
+        # Load with different model name — should reject
+        idx2 = EmbeddingIndex(model_name="different-model")
+        assert not idx2.load(path)
+
+    def test_not_stale_after_load(self, tmp_path):
+        from lattice_lens.services.embedding_service import EmbeddingIndex
+
+        facts = _make_diverse_facts()
+        idx = EmbeddingIndex()
+        idx.build_index(facts)
+
+        path = tmp_path / "embeddings.json"
+        idx.save(path)
+
+        idx2 = EmbeddingIndex()
+        idx2.load(path)
+        assert not idx2.is_stale(facts)
+
+
+@requires_st
+class TestSemanticSearchFunction:
+    """Test the high-level semantic_search() function."""
+
+    def test_basic_search(self, tmp_path):
+        from lattice_lens.services.embedding_service import semantic_search
+
+        facts = _make_diverse_facts()
+        results = semantic_search(
+            facts=facts,
+            query="database",
+            lattice_root=tmp_path,
+            top_k=3,
+            threshold=0.1,
+        )
+        assert len(results) > 0
+        assert results[0]["code"] == "ADR-01"
+
+    def test_tag_filter(self, tmp_path):
+        from lattice_lens.services.embedding_service import semantic_search
+
+        facts = _make_diverse_facts()
+        results = semantic_search(
+            facts=facts,
+            query="architecture decisions",
+            lattice_root=tmp_path,
+            top_k=10,
+            threshold=0.1,
+            tag="security",
+        )
+        # Only MC-01 has security tag
+        for r in results:
+            assert "security" in r["tags"]
+
+    def test_layer_filter(self, tmp_path):
+        from lattice_lens.services.embedding_service import semantic_search
+
+        facts = _make_diverse_facts()
+        results = semantic_search(
+            facts=facts,
+            query="how to do things",
+            lattice_root=tmp_path,
+            top_k=10,
+            threshold=0.1,
+            layer="HOW",
+        )
+        for r in results:
+            assert r["layer"] == "HOW"
+
+    def test_status_filter(self, tmp_path):
+        from lattice_lens.services.embedding_service import semantic_search
+
+        facts = _make_diverse_facts()
+        results = semantic_search(
+            facts=facts,
+            query="database",
+            lattice_root=tmp_path,
+            top_k=10,
+            threshold=0.1,
+            status="Active",
+        )
+        for r in results:
+            assert r["status"] == "Active"
+
+    def test_project_filter(self, tmp_path):
+        from lattice_lens.services.embedding_service import semantic_search
+
+        facts = _make_diverse_facts()
+        results = semantic_search(
+            facts=facts,
+            query="API design",
+            lattice_root=tmp_path,
+            top_k=10,
+            threshold=0.1,
+            project="backend",
+        )
+        for r in results:
+            assert "backend" in r["projects"]
+
+    def test_result_structure(self, tmp_path):
+        from lattice_lens.services.embedding_service import semantic_search
+
+        facts = _make_diverse_facts()
+        results = semantic_search(
+            facts=facts,
+            query="database",
+            lattice_root=tmp_path,
+            top_k=1,
+            threshold=0.1,
+        )
+        assert len(results) == 1
+        r = results[0]
+        assert "code" in r
+        assert "type" in r
+        assert "score" in r
+        assert "layer" in r
+        assert "status" in r
+        assert "tags" in r
+        assert "snippet" in r
+        assert isinstance(r["score"], float)
+        assert 0 <= r["score"] <= 1
+
+    def test_caches_embeddings(self, tmp_path):
+        from lattice_lens.services.embedding_service import EMBEDDINGS_FILE, semantic_search
+
+        facts = _make_diverse_facts()
+        semantic_search(
+            facts=facts,
+            query="database",
+            lattice_root=tmp_path,
+            top_k=1,
+        )
+        # Embeddings file should now exist
+        assert (tmp_path / EMBEDDINGS_FILE).exists()
+
+    def test_force_rebuild(self, tmp_path):
+        from lattice_lens.services.embedding_service import semantic_search
+
+        facts = _make_diverse_facts()
+        # First call
+        r1 = semantic_search(
+            facts=facts, query="database", lattice_root=tmp_path, top_k=3, threshold=0.1
+        )
+        # Force rebuild
+        r2 = semantic_search(
+            facts=facts,
+            query="database",
+            lattice_root=tmp_path,
+            top_k=3,
+            threshold=0.1,
+            force_rebuild=True,
+        )
+        # Should get same results
+        assert [r["code"] for r in r1] == [r["code"] for r in r2]
+
+
+# ---------------------------------------------------------------------------
+# CLI tests (mock the embedding service to avoid model downloads in CI)
+# ---------------------------------------------------------------------------
+
+
+class TestSearchCLI:
+    """Test the search CLI command with mocked embeddings."""
+
+    def test_search_no_args_shows_error(self):
+        from typer.testing import CliRunner
+
+        from lattice_lens.cli.main import app
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["search"])
+        # Should error — no query and no --rebuild-index
+        assert result.exit_code != 0
+
+    def test_search_missing_sentence_transformers(self, monkeypatch):
+        """CLI gracefully handles missing dependencies."""
+        from typer.testing import CliRunner
+
+        from lattice_lens.cli.main import app
+
+        # Patch the import inside search_command
+        runner = CliRunner()
+
+        with patch("lattice_lens.cli.search_command.require_lattice"):
+            # Mock the import to simulate missing sentence-transformers
+            with patch.dict(
+                "sys.modules",
+                {"sentence_transformers": None},
+            ):
+                import lattice_lens.services.embedding_service as es
+
+                original = es.HAS_SENTENCE_TRANSFORMERS
+                es.HAS_SENTENCE_TRANSFORMERS = False
+                try:
+                    result = runner.invoke(app, ["search", "test query"])
+                    assert result.exit_code != 0
+                    assert "sentence-transformers" in result.output or result.exit_code == 1
+                finally:
+                    es.HAS_SENTENCE_TRANSFORMERS = original


### PR DESCRIPTION
## Summary
- New `lattice config embedding` command to view/change the semantic search model
- Model stored in `.lattice/config.yaml` under `embedding.model`
- Changing model auto-deletes cached embeddings (incompatible across models)
- Curated list of 5 recommended models with size/quality/speed comparison

## Commands
```
lattice config embedding                                    # show current
lattice config embedding --model "BAAI/bge-small-en-v1.5"   # switch
lattice config embedding --list                             # recommendations
lattice config embedding --reset                            # back to default
lattice config embedding --json                             # machine output
```

## Recommended Models
| Model | Dims | Size | Quality | Speed |
|---|---|---|---|---|
| all-MiniLM-L6-v2 (default) | 384 | 80MB | Good | Fast |
| BAAI/bge-small-en-v1.5 | 384 | 130MB | Better | Fast |
| all-mpnet-base-v2 | 768 | 420MB | Best | Medium |
| nomic-ai/nomic-embed-text-v1.5 | 768 | 550MB | Best | Medium |
| Snowflake/snowflake-arctic-embed-s | 384 | 130MB | Better | Fast |

## Test Plan
- [x] 20 new tests pass
- [ ] `lattice config embedding` shows default model
- [ ] `--model` changes config.yaml and deletes embeddings.json
- [ ] `--list` shows rich table
- [ ] Next `lattice search` rebuilds with new model

🤖 Generated with [Claude Code](https://claude.com/claude-code)