### PR TITLE
Fix MCP fact_update tool not persisting field changes

### DIFF
--- a/src/lattice_lens/mcp/server.py
+++ b/src/lattice_lens/mcp/server.py
@@ -251,13 +251,13 @@ def create_server(lattice_root: Path, writable: bool = False) -> FastMCP:
             return _json(tool_fact_create(store, data))
 
         @mcp.tool()
-        async def fact_update(code: str, reason: str, **changes) -> str:
+        async def fact_update(code: str, reason: str, changes: dict) -> str:
             """Update an existing fact. Increments version automatically.
 
             Args:
                 code: The fact code to update.
                 reason: Reason for the update.
-                **changes: Fields to update (e.g., fact="new text", tags=["a","b"]).
+                changes: Dict of fields to update (e.g., {"fact": "new text", "tags": ["a","b"]}).
             """
             _refresh()
             return _json(tool_fact_update(store, code, changes, reason))

--- a/src/lattice_lens/store/lens_store.py
+++ b/src/lattice_lens/store/lens_store.py
@@ -191,7 +191,7 @@ class LensStore:
     def update(self, code: str, changes: dict, reason: str) -> Fact:
         """Update a fact remotely."""
         self._require_writable()
-        data = self._call_json("fact_update", {"code": code, "reason": reason, **changes})
+        data = self._call_json("fact_update", {"code": code, "reason": reason, "changes": changes})
         if isinstance(data, dict) and "error" in data:
             raise ValueError(data["error"])
         return Fact.model_validate(data)

--- a/tests/test_lens_store.py
+++ b/tests/test_lens_store.py
@@ -216,7 +216,7 @@ class TestLensStoreWriteOps:
             result = store.update("ADR-01", {"fact": "Updated fact text here."}, "test update")
             mock.assert_called_once_with(
                 "fact_update",
-                {"code": "ADR-01", "reason": "test update", "fact": "Updated fact text here."},
+                {"code": "ADR-01", "reason": "test update", "changes": {"fact": "Updated fact text here."}},
             )
 
         assert result.fact == "Updated fact text here."

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -227,3 +227,96 @@ class TestCallTool:
         get_data = json.loads(get_text)
         assert get_data["code"] == "ADR-01"
         assert "FastMCP" in get_data["fact"]
+
+    def test_fact_update_persists_changes(self, yaml_store):
+        """fact_update via MCP persists field changes, not just version bump."""
+        from lattice_lens.mcp.server import create_server
+
+        _write_role_templates(yaml_store.root / "roles")
+        server = create_server(yaml_store.root, writable=True)
+
+        # Create a fact first
+        fact = make_fact(code="ADR-01")
+        yaml_store.create(fact)
+        original_text = fact.fact
+
+        # Update the fact text via MCP tool
+        update_text = _call_tool_text(
+            server,
+            "fact_update",
+            {
+                "code": "ADR-01",
+                "reason": "clarify wording",
+                "changes": {"fact": "Updated fact text via MCP tool."},
+            },
+        )
+        update_data = json.loads(update_text)
+        assert "error" not in update_data
+        assert update_data["fact"] == "Updated fact text via MCP tool."
+        assert update_data["version"] == 2
+
+        # Verify the change persisted by reading back
+        get_text = _call_tool_text(server, "fact_get", {"code": "ADR-01"})
+        get_data = json.loads(get_text)
+        assert get_data["fact"] == "Updated fact text via MCP tool."
+        assert get_data["fact"] != original_text
+
+    def test_fact_update_persists_tags(self, yaml_store):
+        """fact_update via MCP persists tag changes."""
+        from lattice_lens.mcp.server import create_server
+
+        _write_role_templates(yaml_store.root / "roles")
+        server = create_server(yaml_store.root, writable=True)
+
+        fact = make_fact(code="ADR-01", tags=["old-tag", "keep-tag"])
+        yaml_store.create(fact)
+
+        update_text = _call_tool_text(
+            server,
+            "fact_update",
+            {
+                "code": "ADR-01",
+                "reason": "update tags",
+                "changes": {"tags": ["new-tag", "keep-tag"]},
+            },
+        )
+        update_data = json.loads(update_text)
+        assert "error" not in update_data
+        assert "new-tag" in update_data["tags"]
+        assert "old-tag" not in update_data["tags"]
+
+        # Verify persistence
+        get_text = _call_tool_text(server, "fact_get", {"code": "ADR-01"})
+        get_data = json.loads(get_text)
+        assert "new-tag" in get_data["tags"]
+        assert "old-tag" not in get_data["tags"]
+
+    def test_fact_update_multiple_fields(self, yaml_store):
+        """fact_update via MCP persists multiple field changes at once."""
+        from lattice_lens.mcp.server import create_server
+
+        _write_role_templates(yaml_store.root / "roles")
+        server = create_server(yaml_store.root, writable=True)
+
+        fact = make_fact(code="ADR-01")
+        yaml_store.create(fact)
+
+        update_text = _call_tool_text(
+            server,
+            "fact_update",
+            {
+                "code": "ADR-01",
+                "reason": "major revision",
+                "changes": {
+                    "fact": "Completely rewritten fact text.",
+                    "tags": ["revised", "architecture"],
+                    "owner": "new-team",
+                },
+            },
+        )
+        update_data = json.loads(update_text)
+        assert "error" not in update_data
+        assert update_data["fact"] == "Completely rewritten fact text."
+        assert "revised" in update_data["tags"]
+        assert update_data["owner"] == "new-team"
+        assert update_data["version"] == 2


### PR DESCRIPTION
## Summary

- Fixed `fact_update` MCP server tool using `**kwargs` pattern which FastMCP cannot expose as named parameters in the JSON schema
- Changed to explicit `changes: dict` parameter on the server tool handler
- Updated `LensStore` client to pass changes as a nested `{"changes": {...}}` dict instead of spreading into top-level arguments
- Updated existing `test_lens_store.py` assertion to match new argument format
- Added 3 new MCP server integration tests verifying field changes (text, tags, multiple fields) are actually persisted

Closes #47

## Test plan

- [x] `test_fact_update_persists_changes` - verifies fact text changes are persisted through MCP server
- [x] `test_fact_update_persists_tags` - verifies tag changes are persisted through MCP server
- [x] `test_fact_update_multiple_fields` - verifies simultaneous changes to fact, tags, and owner are persisted
- [x] All 68 MCP/lens tests pass (`test_mcp_server.py`, `test_mcp_tools.py`, `test_lens_store.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)