### PR TITLE
Fix validation ignoring custom types.yaml (#46)

### DIFF
--- a/src/lattice_lens/services/type_service.py
+++ b/src/lattice_lens/services/type_service.py
@@ -88,8 +88,23 @@ for _layer, _prefixes in CANONICAL_TYPES.items():
         _PREFIX_TO_DESC[_prefix] = _info["description"]
 
 
-def canonical_type_for_prefix(prefix: str) -> str | None:
-    """Look up the canonical type string for a code prefix."""
+def canonical_type_for_prefix(prefix: str, lattice_root: Path | None = None) -> str | None:
+    """Look up the canonical type string for a code prefix.
+
+    When *lattice_root* is provided the function reads the on-disk
+    ``types.yaml`` first (which may contain custom type definitions)
+    and falls back to the hardcoded ``CANONICAL_TYPES`` map only when
+    the file is absent or doesn't cover the requested prefix.
+    """
+    if lattice_root is not None:
+        registry = read_type_registry(lattice_root)
+        if registry is not None:
+            for layer_prefixes in registry.values():
+                if isinstance(layer_prefixes, dict) and prefix in layer_prefixes:
+                    info = layer_prefixes[prefix]
+                    if isinstance(info, dict):
+                        return info.get("name")
+                    return str(info)
     return _PREFIX_TO_TYPE.get(prefix)
 
 

--- a/src/lattice_lens/services/validate_service.py
+++ b/src/lattice_lens/services/validate_service.py
@@ -128,9 +128,10 @@ def validate_lattice(facts_dir: Path) -> ValidationResult:
     # Check type canonicality (RISK-03 mitigation)
     from lattice_lens.services.type_service import canonical_type_for_prefix
 
+    lattice_root = facts_dir.parent
     for fact in all_facts:
         prefix = fact.code.split("-")[0]
-        canonical = canonical_type_for_prefix(prefix)
+        canonical = canonical_type_for_prefix(prefix, lattice_root=lattice_root)
         if canonical and fact.type != canonical:
             result.add_warning(
                 f"{fact.code}: Type '{fact.type}' differs from canonical "

--- a/tests/test_type_service.py
+++ b/tests/test_type_service.py
@@ -46,6 +46,36 @@ class TestCanonicalTypes:
         assert canonical_type_for_prefix("UNKNOWN") is None
         assert description_for_prefix("UNKNOWN") is None
 
+    def test_canonical_type_reads_types_yaml(self, tmp_lattice):
+        """canonical_type_for_prefix reads types.yaml when lattice_root is provided."""
+        custom = {
+            "GUARDRAILS": {
+                "RISK": {
+                    "name": "Custom Risk Type",
+                    "description": "Custom risk description",
+                },
+            },
+        }
+        write_type_registry(tmp_lattice, custom)
+
+        result = canonical_type_for_prefix("RISK", lattice_root=tmp_lattice)
+        assert result == "Custom Risk Type"
+
+        assert canonical_type_for_prefix("RISK") == "Risk Register Entry"
+
+    def test_canonical_type_falls_back_when_no_types_yaml(self, tmp_lattice):
+        """canonical_type_for_prefix falls back to hardcoded when types.yaml is absent."""
+        result = canonical_type_for_prefix("ADR", lattice_root=tmp_lattice)
+        assert result == "Architecture Decision Record"
+
+    def test_canonical_type_falls_back_for_uncovered_prefix(self, tmp_lattice):
+        """canonical_type_for_prefix falls back for prefixes not in types.yaml."""
+        custom = {"GUARDRAILS": {"RISK": {"name": "Custom Risk", "description": "desc"}}}
+        write_type_registry(tmp_lattice, custom)
+
+        result = canonical_type_for_prefix("ADR", lattice_root=tmp_lattice)
+        assert result == "Architecture Decision Record"
+
 
 class TestAuditTypes:
     def test_finds_mismatches(self, yaml_store):

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -244,6 +244,59 @@ class TestValidation:
         assert not any("stale" in w.lower() for w in result.warnings)
 
 
+    def test_custom_types_yaml_respected(self, yaml_store: YamlFileStore):
+        """Validation uses custom types.yaml instead of only hardcoded CANONICAL_TYPES (#46)."""
+        from lattice_lens.services.type_service import write_type_registry
+
+        custom = {
+            "GUARDRAILS": {
+                "RISK": {
+                    "name": "Custom Risk Type",
+                    "description": "Custom risk description",
+                },
+            },
+        }
+        write_type_registry(yaml_store.root, custom)
+
+        fact = make_fact(
+            code="RISK-01",
+            layer="GUARDRAILS",
+            type="Custom Risk Type",
+            tags=["risk", "test"],
+        )
+        yaml_store.create(fact)
+
+        result = validate_lattice(yaml_store.facts_dir)
+        assert not any("differs from canonical" in w for w in result.warnings)
+
+    def test_custom_types_yaml_detects_mismatch(self, yaml_store: YamlFileStore):
+        """Validation flags mismatches against types.yaml, not just hardcoded map (#46)."""
+        from lattice_lens.services.type_service import write_type_registry
+
+        custom = {
+            "GUARDRAILS": {
+                "RISK": {
+                    "name": "Custom Risk Type",
+                    "description": "Custom risk description",
+                },
+            },
+        }
+        write_type_registry(yaml_store.root, custom)
+
+        fact = make_fact(
+            code="RISK-01",
+            layer="GUARDRAILS",
+            type="Risk Register Entry",
+            tags=["risk", "test"],
+        )
+        yaml_store.create(fact)
+
+        result = validate_lattice(yaml_store.facts_dir)
+        assert any(
+            "differs from canonical" in w and "Custom Risk Type" in w for w in result.warnings
+        )
+
+
 # ── fix_lattice tests ──
 
 


### PR DESCRIPTION
## Summary
- `lattice validate` now loads and respects custom type definitions from `.lattice/types.yaml` instead of only using hardcoded `CANONICAL_TYPES`
- Extended `canonical_type_for_prefix()` with optional `lattice_root` parameter to check the on-disk type registry first, falling back to hardcoded types
- Brings validation behavior in line with `lattice types audit` which already respected `types.yaml`

Closes #46

## Test plan
- [x] Added `test_canonical_type_reads_types_yaml` - verifies custom types.yaml is read when lattice_root is provided
- [x] Added `test_canonical_type_falls_back_when_no_types_yaml` - verifies fallback to hardcoded types
- [x] Added `test_canonical_type_falls_back_for_uncovered_prefix` - verifies fallback for prefixes not in custom registry
- [x] Added `test_custom_types_yaml_respected` - verifies validation accepts facts matching custom types.yaml
- [x] Added `test_custom_types_yaml_detects_mismatch` - verifies validation warns when fact doesn't match custom types.yaml
- [x] All 47 targeted tests pass, full suite 768 passed (13 pre-existing failures unrelated)

Generated with Claude Code