### PR TITLE
Fix NoneType iteration error in fact validation

### DIFF
--- a/src/lattice_lens/models.py
+++ b/src/lattice_lens/models.py
@@ -72,8 +72,10 @@ class Fact(BaseModel):
 
     @field_validator("refs", mode="before")
     @classmethod
-    def normalize_refs(cls, v: list) -> list[FactRef]:
-        """Accept list[str], list[dict], or list[FactRef]. Strings become relates edges."""
+    def normalize_refs(cls, v: list | None) -> list[FactRef]:
+        """Accept list[str], list[dict], list[FactRef], or None. Strings become relates edges."""
+        if v is None:
+            return []
         result = []
         for item in v:
             if isinstance(item, str):
@@ -91,9 +93,11 @@ class Fact(BaseModel):
         """Return just the ref target codes (backward-compat convenience)."""
         return [r.code for r in self.refs]
 
-    @field_validator("projects")
+    @field_validator("projects", mode="before")
     @classmethod
-    def normalize_projects(cls, v: list[str]) -> list[str]:
+    def normalize_projects(cls, v: list[str] | None) -> list[str]:
+        if v is None:
+            return []
         normalized = []
         for entry in v:
             entry = entry.strip()

--- a/src/lattice_lens/services/validate_service.py
+++ b/src/lattice_lens/services/validate_service.py
@@ -101,7 +101,7 @@ def validate_lattice(facts_dir: Path) -> ValidationResult:
 
     # Check ref integrity (soft warnings)
     for fact in all_facts:
-        for ref in fact.refs:
+        for ref in fact.refs or []:
             if ref.code not in all_codes:
                 result.add_warning(f"{fact.code}: Reference target '{ref.code}' does not exist")
 
@@ -111,7 +111,7 @@ def validate_lattice(facts_dir: Path) -> ValidationResult:
 
     supersedes_targets: set[str] = set()
     for fact in all_facts:
-        for ref in fact.refs:
+        for ref in fact.refs or []:
             if ref.rel == EdgeType.SUPERSEDES:
                 supersedes_targets.add(ref.code)
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -243,6 +243,53 @@ class TestValidation:
         result = validate_lattice(yaml_store.facts_dir)
         assert not any("stale" in w.lower() for w in result.warnings)
 
+    def test_refs_null_no_crash(self, yaml_store: YamlFileStore):
+        """Fact with refs: null does not crash validation (issue #45)."""
+        data = make_fact(code="ADR-10").model_dump(mode="json")
+        data["refs"] = None
+        path = yaml_store.facts_dir / "ADR-10.yaml"
+        with open(path, "w") as f:
+            yaml_rw.dump(data, f)
+
+        result = validate_lattice(yaml_store.facts_dir)
+        # Should not raise TypeError; fact is otherwise valid
+        assert result.ok
+
+    def test_refs_missing_no_crash(self, yaml_store: YamlFileStore):
+        """Fact with refs field entirely absent does not crash validation (issue #45)."""
+        data = make_fact(code="ADR-10").model_dump(mode="json")
+        del data["refs"]
+        path = yaml_store.facts_dir / "ADR-10.yaml"
+        with open(path, "w") as f:
+            yaml_rw.dump(data, f)
+
+        result = validate_lattice(yaml_store.facts_dir)
+        assert result.ok
+
+    def test_projects_null_no_crash(self, yaml_store: YamlFileStore):
+        """Fact with projects: null does not crash validation."""
+        data = make_fact(code="ADR-10").model_dump(mode="json")
+        data["projects"] = None
+        path = yaml_store.facts_dir / "ADR-10.yaml"
+        with open(path, "w") as f:
+            yaml_rw.dump(data, f)
+
+        result = validate_lattice(yaml_store.facts_dir)
+        assert result.ok
+
+    def test_tags_null_is_validation_error(self, yaml_store: YamlFileStore):
+        """Fact with tags: null is caught as a validation error (tags are required)."""
+        data = make_fact(code="ADR-10").model_dump(mode="json")
+        data["tags"] = None
+        path = yaml_store.facts_dir / "ADR-10.yaml"
+        with open(path, "w") as f:
+            yaml_rw.dump(data, f)
+
+        result = validate_lattice(yaml_store.facts_dir)
+        # tags: null with min_length=2 should fail Pydantic validation, not crash
+        assert not result.ok
+        assert any("Validation error" in e for e in result.errors)
+
 
 # ── fix_lattice tests ──
 


### PR DESCRIPTION
## Summary
- Add null checks to `normalize_refs` and `normalize_projects` Pydantic validators in `models.py` so `refs: null` and `projects: null` in YAML are coerced to empty lists instead of crashing
- Add defensive `or []` iteration guards in `validate_service.py` for the two loops over `fact.refs`
- Add 4 regression tests: `refs: null`, missing `refs`, `projects: null`, and `tags: null` (which should be a validation error, not a crash)

Closes #45

## Test plan
- [x] `test_refs_null_no_crash` -- fact with `refs: null` validates without TypeError
- [x] `test_refs_missing_no_crash` -- fact with `refs` field absent validates without error
- [x] `test_projects_null_no_crash` -- fact with `projects: null` validates without TypeError
- [x] `test_tags_null_is_validation_error` -- fact with `tags: null` is caught as Pydantic validation error, not a crash
- [x] All 32 validation tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)